### PR TITLE
fix: close critical authentication and tenant-isolation gaps

### DIFF
--- a/__tests__/auth-callback.test.ts
+++ b/__tests__/auth-callback.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { getCallbackOrigin, sanitizeCallbackPath } from "@/app/auth/callback/route"
+
+const originalSiteUrl = process.env.NEXT_PUBLIC_SITE_URL
+const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL
+
+afterEach(() => {
+  if (originalSiteUrl === undefined) delete process.env.NEXT_PUBLIC_SITE_URL
+  else process.env.NEXT_PUBLIC_SITE_URL = originalSiteUrl
+  if (originalAppUrl === undefined) delete process.env.NEXT_PUBLIC_APP_URL
+  else process.env.NEXT_PUBLIC_APP_URL = originalAppUrl
+})
+
+describe("authentication callback redirects", () => {
+  it.each([
+    ["https://evil.example", "/"],
+    ["//evil.example/path", "/"],
+    ["/\\evil.example/path", "/"],
+    ["dashboard", "/"],
+    ["/dashboard?tab=security", "/dashboard?tab=security"],
+  ])("sanitizes %s", (input, expected) => {
+    expect(sanitizeCallbackPath(input)).toBe(expected)
+  })
+
+  it("uses the configured origin and ignores forwarded host headers", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "https://digit-ai.org/base"
+    const request = new Request("https://internal:3000/auth/callback", {
+      headers: { "x-forwarded-host": "evil.example" },
+    })
+
+    expect(getCallbackOrigin(request)).toBe("https://digit-ai.org")
+  })
+
+  it("rejects an invalid configured origin", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "not a URL"
+    expect(getCallbackOrigin(new Request("https://internal/auth/callback"))).toBeNull()
+  })
+})

--- a/__tests__/billing.test.ts
+++ b/__tests__/billing.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { startTrial, processTrialEnd, isWithinRefundWindow, processRefund, cancelSubscription, getYearlyMilestone } from "@/lib/billing/subscription-lifecycle"
+import { createServiceClient } from "@/lib/supabase/service"
+
+const stripeMocks = vi.hoisted(() => ({
+  retrieve: vi.fn(),
+  update: vi.fn(),
+  cancel: vi.fn(),
+  listInvoices: vi.fn(),
+  createRefund: vi.fn(),
+}))
 
 // Mock server-only modules
 vi.mock("server-only", () => ({}))
@@ -11,6 +20,25 @@ vi.mock("@/lib/logging", () => ({
   logError: vi.fn(),
   logException: vi.fn()
 }))
+vi.mock("@/lib/analytics/billing-events", () => ({
+  trackTrialStarted: vi.fn(),
+  trackTrialEnded: vi.fn(),
+  trackFirstPayment: vi.fn(),
+  trackRefundRequested: vi.fn(),
+  trackRefundProcessed: vi.fn(),
+  trackSubscriptionCancelled: vi.fn(),
+}))
+vi.mock("@/lib/billing/stripe", () => ({
+  stripe: {
+    subscriptions: {
+      retrieve: stripeMocks.retrieve,
+      update: stripeMocks.update,
+      cancel: stripeMocks.cancel,
+    },
+    invoices: { list: stripeMocks.listInvoices },
+    refunds: { create: stripeMocks.createRefund },
+  },
+}))
 
 const mockSupabase = {
   from: vi.fn().mockReturnThis(),
@@ -19,16 +47,27 @@ const mockSupabase = {
   update: vi.fn().mockReturnThis(),
   eq: vi.fn().mockReturnThis(),
   single: vi.fn(),
+  maybeSingle: vi.fn(),
 }
 
 beforeEach(() => {
-  vi.mocked(createServiceClient).mockReturnValue(mockSupabase as any)
+  vi.clearAllMocks()
+  mockSupabase.from.mockReturnThis()
+  mockSupabase.select.mockReturnThis()
+  mockSupabase.insert.mockReturnThis()
+  mockSupabase.update.mockReturnThis()
+  mockSupabase.eq.mockReturnThis()
+  mockSupabase.single.mockResolvedValue({ data: null })
+  mockSupabase.maybeSingle.mockResolvedValue({ data: null })
+  vi.mocked(createServiceClient).mockReturnValue(
+    mockSupabase as unknown as ReturnType<typeof createServiceClient>
+  )
 })
 
 describe("Subscription Lifecycle", () => {
   describe("startTrial", () => {
     it("should start a trial successfully", async () => {
-      mockSupabase.single.mockResolvedValueOnce({ data: { id: "sub_123" } })
+      mockSupabase.maybeSingle.mockResolvedValueOnce({ data: null })
       
       const result = await startTrial("org_123", "plan_pro", "user_123")
       
@@ -92,46 +131,70 @@ describe("Subscription Lifecycle", () => {
   
   describe("processRefund", () => {
     it("should process refund successfully", async () => {
-      mockSupabase.single.mockResolvedValueOnce({
-        data: {
-          id: "sub_123",
-          plan_id: "plan_pro",
-          stripe_subscription_id: "stripe_123"
-        }
+      const mockDate = new Date()
+      mockDate.setDate(mockDate.getDate() - 15)
+      mockSupabase.single
+        .mockResolvedValueOnce({
+          data: { current_period_start: mockDate.toISOString(), billing_interval: "month" }
+        })
+        .mockResolvedValueOnce({
+          data: {
+            id: "sub_123",
+            plan_id: "professional",
+            stripe_subscription_id: "stripe_123"
+          }
+        })
+      stripeMocks.listInvoices.mockResolvedValueOnce({
+        data: [{ payment_intent: "pi_123" }]
       })
       
       const result = await processRefund("org_123", "user_123")
       expect(result.success).toBe(true)
+      expect(stripeMocks.cancel).toHaveBeenCalledWith("stripe_123")
+      expect(stripeMocks.createRefund).toHaveBeenCalledWith({ payment_intent: "pi_123" })
     })
   })
   
   describe("cancelSubscription", () => {
     it("should cancel monthly subscription successfully", async () => {
-      mockSupabase.single.mockResolvedValueOnce({
-        data: {
-          id: "sub_123",
-          plan_id: "plan_pro",
-          billing_interval: "month",
-          stripe_subscription_id: "stripe_123"
-        }
-      })
+      const mockDate = new Date()
+      mockDate.setDate(mockDate.getDate() - 45)
+      mockSupabase.single
+        .mockResolvedValueOnce({
+          data: {
+            id: "sub_123",
+            plan_id: "professional",
+            billing_interval: "month",
+            stripe_subscription_id: "stripe_123"
+          }
+        })
+        .mockResolvedValueOnce({
+          data: { current_period_start: mockDate.toISOString(), billing_interval: "month" }
+        })
       
       const result = await cancelSubscription("org_123", "user_123")
       expect(result.charged).toBe(true)
+      expect(stripeMocks.update).toHaveBeenCalledWith("stripe_123", {
+        cancel_at_period_end: true,
+      })
     })
     
     it("should cancel yearly subscription after minimum period", async () => {
       const mockDate = new Date()
       mockDate.setMonth(mockDate.getMonth() - 4) // 4 months ago
       
-      mockSupabase.single.mockResolvedValueOnce({
-        data: {
-          id: "sub_123",
-          plan_id: "plan_pro",
-          billing_interval: "year",
-          current_period_start: mockDate.toISOString()
-        }
-      })
+      mockSupabase.single
+        .mockResolvedValueOnce({
+          data: {
+            id: "sub_123",
+            plan_id: "professional",
+            billing_interval: "year",
+            current_period_start: mockDate.toISOString()
+          }
+        })
+        .mockResolvedValueOnce({
+          data: { current_period_start: mockDate.toISOString(), billing_interval: "year" }
+        })
       
       const result = await cancelSubscription("org_123", "user_123")
       expect(result.charged).toBe(true)

--- a/__tests__/billing.test.ts
+++ b/__tests__/billing.test.ts
@@ -127,6 +127,19 @@ describe("Subscription Lifecycle", () => {
       const result = await isWithinRefundWindow("org_123")
       expect(result).toBe(false)
     })
+
+    it("should return false for a future billing start date", async () => {
+      const futureDate = new Date()
+      futureDate.setDate(futureDate.getDate() + 1)
+      mockSupabase.single.mockResolvedValueOnce({
+        data: {
+          current_period_start: futureDate.toISOString(),
+          billing_interval: "month",
+        },
+      })
+
+      await expect(isWithinRefundWindow("org_123")).resolves.toBe(false)
+    })
   })
   
   describe("processRefund", () => {

--- a/__tests__/passwordless-service.test.ts
+++ b/__tests__/passwordless-service.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { createServiceClient } = vi.hoisted(() => ({ createServiceClient: vi.fn() }))
+
+vi.mock("server-only", () => ({}))
+vi.mock("@/lib/supabase/service", () => ({ createServiceClient }))
+vi.mock("@/lib/logging", () => ({
+  logger: { logWarn: vi.fn(), logError: vi.fn() },
+}))
+
+import { hashToken, verifyMagicLink } from "@/lib/auth/passwordless/service"
+
+function chain(result: unknown) {
+  const builder: Record<string, ReturnType<typeof vi.fn>> = {}
+  for (const method of ["select", "eq", "update"]) {
+    builder[method] = vi.fn(() => builder)
+  }
+  builder.maybeSingle = vi.fn(async () => result)
+  return builder
+}
+
+describe("passwordless token consumption", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("returns the user only when the unused token is atomically claimed", async () => {
+    const record = {
+      id: "token-1",
+      user_id: "user-1",
+      expires_at: new Date(Date.now() + 60_000).toISOString(),
+    }
+    const lookup = chain({ data: record })
+    const claim = chain({ data: { user_id: "user-1" }, error: null })
+    createServiceClient.mockReturnValue({
+      from: vi.fn().mockReturnValueOnce(lookup).mockReturnValueOnce(claim),
+    })
+
+    await expect(verifyMagicLink("secret", "USER@example.com")).resolves.toBe("user-1")
+    expect(lookup.eq).toHaveBeenCalledWith("token_hash", hashToken("secret"))
+    expect(claim.eq).toHaveBeenCalledWith("used", false)
+  })
+
+  it("rejects a token lost to a concurrent claimant", async () => {
+    const lookup = chain({
+      data: {
+        id: "token-1",
+        user_id: "user-1",
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+      },
+    })
+    const claim = chain({ data: null, error: null })
+    createServiceClient.mockReturnValue({
+      from: vi.fn().mockReturnValueOnce(lookup).mockReturnValueOnce(claim),
+    })
+
+    await expect(verifyMagicLink("secret", "user@example.com")).resolves.toBeNull()
+  })
+})

--- a/__tests__/webhook-db-errors.test.ts
+++ b/__tests__/webhook-db-errors.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  createServiceClient: vi.fn(),
+  claim: vi.fn(),
+  complete: vi.fn(),
+  fail: vi.fn(),
+}))
+
+vi.mock("server-only", () => ({}))
+vi.mock("@/lib/supabase/service", () => ({ createServiceClient: mocks.createServiceClient }))
+vi.mock("@/lib/auth/audit", () => ({ logAuthEvent: vi.fn() }))
+vi.mock("@/lib/logging", () => ({
+  logger: { logInfo: vi.fn(), logError: vi.fn(), logWarn: vi.fn() },
+}))
+vi.mock("@/lib/billing/idempotency", () => ({
+  claimWebhookEvent: mocks.claim,
+  completeWebhookEvent: mocks.complete,
+  failWebhookEvent: mocks.fail,
+}))
+
+import { handleRazorpayWebhook } from "../lib/billing/razorpay.ts"
+
+describe("payment webhook database failures", () => {
+  it("fails the lease instead of completing after a returned Supabase error", async () => {
+    const databaseError = { message: "database unavailable" }
+    const eq = vi.fn().mockResolvedValue({ error: databaseError })
+    const update = vi.fn().mockReturnValue({ eq })
+    mocks.createServiceClient.mockReturnValue({ from: vi.fn().mockReturnValue({ update }) })
+    mocks.claim.mockResolvedValue(true)
+
+    const payload = {
+      event: "subscription.activated",
+      payload: {
+        subscription: {
+          entity: {
+            id: "sub_1",
+            customer_id: "customer_1",
+            metadata: { organization_id: "org_1" },
+          },
+        },
+      },
+    }
+
+    await expect(handleRazorpayWebhook(payload, "event_1")).rejects.toBe(databaseError)
+    expect(mocks.complete).not.toHaveBeenCalled()
+    expect(mocks.fail).toHaveBeenCalledWith("razorpay", "event_1", databaseError)
+  })
+})

--- a/__tests__/webhook-idempotency.test.ts
+++ b/__tests__/webhook-idempotency.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { claimWebhookEvent, completeWebhookEvent, failWebhookEvent } from "@/lib/billing/idempotency"
+import { createServiceClient } from "@/lib/supabase/service"
+
+vi.mock("@/lib/supabase/service", () => ({ createServiceClient: vi.fn() }))
+
+function query(result: { data?: unknown; error?: unknown } = {}) {
+  const builder = {
+    select: vi.fn(),
+    update: vi.fn(),
+    eq: vi.fn(),
+    single: vi.fn(),
+    maybeSingle: vi.fn(),
+  }
+  builder.select.mockReturnValue(builder)
+  builder.update.mockReturnValue(builder)
+  builder.eq.mockReturnValue(builder)
+  builder.single.mockResolvedValue(result)
+  builder.maybeSingle.mockResolvedValue(result)
+  return builder
+}
+
+function database(...builders: unknown[]) {
+  return { from: vi.fn().mockImplementation(() => builders.shift()) }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe("webhook event leases", () => {
+  it("claims a new delivery as processing", async () => {
+    const insert = vi.fn().mockResolvedValue({ error: null })
+    vi.mocked(createServiceClient).mockReturnValue(database({ insert }) as never)
+
+    await expect(claimWebhookEvent("stripe", "evt_1", "invoice.paid")).resolves.toBe(true)
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({
+      status: "processing",
+      attempts: 1,
+    }))
+  })
+
+  it("suppresses an already completed delivery", async () => {
+    const duplicate = { insert: vi.fn().mockResolvedValue({ error: { code: "23505" } }) }
+    const existing = query({ data: { status: "completed", claimed_at: null, attempts: 1 }, error: null })
+    vi.mocked(createServiceClient).mockReturnValue(database(duplicate, existing) as never)
+
+    await expect(claimWebhookEvent("stripe", "evt_1")).resolves.toBe(false)
+  })
+
+  it("reclaims a failed delivery for retry", async () => {
+    const duplicate = { insert: vi.fn().mockResolvedValue({ error: { code: "23505" } }) }
+    const existing = query({ data: { status: "failed", claimed_at: "2026-07-19T00:00:00.000Z", attempts: 1 }, error: null })
+    const retry = query({ data: { id: "row_1" }, error: null })
+    vi.mocked(createServiceClient).mockReturnValue(database(duplicate, existing, retry) as never)
+
+    await expect(claimWebhookEvent("razorpay", "evt_2")).resolves.toBe(true)
+    expect(retry.update).toHaveBeenCalledWith(expect.objectContaining({ status: "processing", attempts: 2 }))
+  })
+
+  it("does not run concurrently while a lease is active", async () => {
+    const duplicate = { insert: vi.fn().mockResolvedValue({ error: { code: "23505" } }) }
+    const existing = query({ data: { status: "processing", claimed_at: new Date().toISOString(), attempts: 1 }, error: null })
+    vi.mocked(createServiceClient).mockReturnValue(database(duplicate, existing) as never)
+
+    await expect(claimWebhookEvent("stripe", "evt_3")).rejects.toThrow("already processing")
+  })
+
+  it("reclaims an expired processing lease", async () => {
+    const duplicate = { insert: vi.fn().mockResolvedValue({ error: { code: "23505" } }) }
+    const staleClaim = new Date(Date.now() - 10 * 60 * 1000).toISOString()
+    const existing = query({ data: { status: "processing", claimed_at: staleClaim, attempts: 2 }, error: null })
+    const retry = query({ data: { id: "row_1" }, error: null })
+    vi.mocked(createServiceClient).mockReturnValue(database(duplicate, existing, retry) as never)
+
+    await expect(claimWebhookEvent("stripe", "evt_stale")).resolves.toBe(true)
+    expect(retry.eq).toHaveBeenCalledWith("claimed_at", staleClaim)
+  })
+
+  it("marks successful and failed deliveries explicitly", async () => {
+    const completed = query({ data: { id: "row_1" }, error: null })
+    const failed = query({ error: null })
+    vi.mocked(createServiceClient)
+      .mockReturnValueOnce(database(completed) as never)
+      .mockReturnValueOnce(database(failed) as never)
+
+    await completeWebhookEvent("stripe", "evt_4")
+    await failWebhookEvent("stripe", "evt_5", new Error("temporary failure"))
+
+    expect(completed.update).toHaveBeenCalledWith(expect.objectContaining({ status: "completed" }))
+    expect(failed.update).toHaveBeenCalledWith(expect.objectContaining({
+      status: "failed",
+      last_error: "temporary failure",
+    }))
+  })
+})

--- a/app/api/auth/create-trial/route.ts
+++ b/app/api/auth/create-trial/route.ts
@@ -6,6 +6,7 @@ import { startTrial } from "@/lib/billing/subscription-lifecycle"
 import { logAuthEvent } from "@/lib/auth/audit"
 import { v4 as uuidv4 } from "uuid"
 import { createHash } from "node:crypto"
+import { getAuthenticatedUser, handleAuthError } from "@/lib/auth/server-auth"
 
 function generateSlug(name: string): string {
   return name
@@ -19,16 +20,41 @@ function generateSlug(name: string): string {
 // Creates an organization, profile, and trial subscription for a new user.
 export async function POST(request: Request) {
   try {
-    const { userId, email, fullName, companyName } = await request.json()
+    const user = await getAuthenticatedUser()
+    const { fullName, companyName } = await request.json()
+    const userId = user.id
+    const email = user.email
 
-    if (!userId || !email) {
+    if (!email) {
       return NextResponse.json(
-        { error: "Missing required fields: userId, email" },
+        { error: "The authenticated account does not have an email address" },
         { status: 400 }
       )
     }
 
     const db = createServiceClient()
+
+    // Trial provisioning is a one-time signup operation. Never upsert here:
+    // overwriting an existing profile could move an account to another tenant
+    // and grant it an administrator role.
+    const { data: existingProfile, error: profileLookupError } = await db
+      .from("profiles")
+      .select("id")
+      .eq("id", userId)
+      .maybeSingle()
+
+    if (profileLookupError) {
+      console.error("[v0] Error checking existing profile:", profileLookupError)
+      return NextResponse.json({ error: "Failed to verify account state" }, { status: 500 })
+    }
+
+    if (existingProfile) {
+      return NextResponse.json(
+        { error: "A profile already exists for this account" },
+        { status: 409 }
+      )
+    }
+
     const organizationId = uuidv4()
     const slug = generateSlug(companyName || email.split("@")[0])
 
@@ -48,8 +74,8 @@ export async function POST(request: Request) {
       )
     }
 
-    // 2. Create or update profile
-    const { error: profileError } = await db.from("profiles").upsert({
+    // 2. Create the profile. A concurrent retry fails instead of overwriting it.
+    const { error: profileError } = await db.from("profiles").insert({
       id: userId,
       email,
       full_name: fullName || email.split("@")[0],
@@ -57,7 +83,7 @@ export async function POST(request: Request) {
       role: "admin",
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
-    }, { onConflict: "id" })
+    })
 
     if (profileError) {
       console.error("[v0] Error creating profile:", profileError)
@@ -144,6 +170,9 @@ export async function POST(request: Request) {
       message: "Trial created successfully",
     })
   } catch (error) {
+    if (error instanceof Error && ["Unauthorized", "Suspended"].includes(error.message)) {
+      return handleAuthError(error)
+    }
     console.error("[v0] Error creating trial:", error)
     return NextResponse.json(
       { error: "An unexpected error occurred while creating your trial" },

--- a/app/api/auth/passkeys/authenticate/route.ts
+++ b/app/api/auth/passkeys/authenticate/route.ts
@@ -3,127 +3,189 @@ import {
   generateAuthenticationOptions,
   verifyAuthenticationResponse,
 } from "@simplewebauthn/server"
+import type { AuthenticationResponseJSON } from "@simplewebauthn/server"
 import { createClient } from "@/lib/supabase/server"
 import { createServiceClient } from "@/lib/supabase/service"
 
+const CHALLENGE_COOKIE = "digit_passkey_auth_flow"
+const CHALLENGE_TTL_MS = 5 * 60 * 1000
+
+function webAuthnConfig() {
+  const origin = new URL(process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000")
+  return { origin: origin.origin, rpID: origin.hostname }
+}
+
+function clearChallengeCookie(response: NextResponse) {
+  response.cookies.set(CHALLENGE_COOKIE, "", {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: process.env.NODE_ENV === "production",
+    path: "/api/auth/passkeys/authenticate",
+    maxAge: 0,
+  })
+  return response
+}
+
 export async function POST(req: NextRequest) {
   try {
-    const { action, data } = await req.json()
+    const body = await req.json() as {
+      action?: "options" | "verify"
+      credential?: AuthenticationResponseJSON
+    }
+    const db = createServiceClient()
+    const { origin, rpID } = webAuthnConfig()
 
-    if (action === "start-authentication") {
+    if (body.action === "options") {
       const options = await generateAuthenticationOptions({
-        rpID: process.env.NEXT_PUBLIC_APP_URL?.split("//")[1] || "localhost:3000",
+        rpID,
+        userVerification: "required",
       })
+      const expiresAt = new Date(Date.now() + CHALLENGE_TTL_MS).toISOString()
+      const { data: flow, error } = await db
+        .from("passkey_authentication_challenges")
+        .insert({ challenge: options.challenge, expires_at: expiresAt })
+        .select("id")
+        .single()
 
-      return NextResponse.json({
-        options,
-        challenge: options.challenge,
+      if (error || !flow) {
+        return NextResponse.json({ error: "Unable to start passkey authentication" }, { status: 503 })
+      }
+
+      const response = NextResponse.json(options)
+      response.cookies.set(CHALLENGE_COOKIE, flow.id, {
+        httpOnly: true,
+        sameSite: "strict",
+        secure: process.env.NODE_ENV === "production",
+        path: "/api/auth/passkeys/authenticate",
+        maxAge: CHALLENGE_TTL_MS / 1000,
       })
+      return response
     }
 
-    if (action === "verify-authentication") {
-      const { credential, challenge, credentialID } = data
-
-      try {
-        const supabase = await createClient()
-        // Passkey lookups happen BEFORE the user has a session, so RLS would
-        // hide the row. Use the service client (RLS-exempt) for the credential
-        // table; possession of the credential + the verified WebAuthn signature
-        // is the proof, not an active session.
-        const db = createServiceClient()
-
-        // Get passkey from database
-        const { data: passkey, error: passkeyError } = await db
-          .from("passkeys")
-          .select("*")
-          .eq("credential_id", credentialID)
-          .single()
-
-        if (passkeyError || !passkey) {
-          return NextResponse.json(
-            { error: "Passkey not found" },
-            { status: 404 }
-          )
-        }
-
-        // Verify authentication
-        const verification = await verifyAuthenticationResponse({
-          response: credential,
-          expectedChallenge: challenge,
-          expectedOrigin: process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
-          expectedRPID: process.env.NEXT_PUBLIC_APP_URL?.split("//")[1] || "localhost:3000",
-          credential: {
-            id: credentialID,
-            publicKey: Buffer.from(passkey.public_key, "base64"),
-            counter: passkey.counter,
-            transports: passkey.transports || [],
-          },
-        })
-
-        if (!verification.verified) {
-          return NextResponse.json(
-            { error: "Verification failed" },
-            { status: 400 }
-          )
-        }
-
-        // Update counter and last_used_at
-        const { error: updateError } = await db
-          .from("passkeys")
-          .update({
-            counter: verification.authenticationInfo?.newCounter || passkey.counter,
-            last_used_at: new Date().toISOString(),
-          })
-          .eq("credential_id", credentialID)
-
-        if (updateError) {
-          console.error("Failed to update passkey counter:", updateError)
-        }
-
-        // Sign in the user
-        const { data: { user }, error: userError } = await supabase.auth.getUser()
-
-        if (userError || !user) {
-          // Get user from the passkey association
-          const { data: userData, error: getUserError } = await db
-            .from("passkeys")
-            .select("user_id")
-            .eq("credential_id", credentialID)
-            .single()
-
-          if (getUserError || !userData) {
-            return NextResponse.json(
-              { error: "User not found" },
-              { status: 404 }
-            )
-          }
-
-          // Return success - client will handle redirect
-          return NextResponse.json({
-            success: true,
-            userId: userData.user_id,
-            message: "Passkey authenticated successfully",
-          })
-        }
-
-        return NextResponse.json({
-          success: true,
-          userId: passkey.user_id,
-          message: "Passkey authenticated successfully",
-        })
-      } catch (err: unknown) {
-        return NextResponse.json(
-          { error: `Verification error: ${err instanceof Error ? err.message : String(err)}` },
-          { status: 400 }
+    if (body.action === "verify") {
+      const credential = body.credential
+      const flowId = req.cookies.get(CHALLENGE_COOKIE)?.value
+      if (!credential || !flowId) {
+        return clearChallengeCookie(
+          NextResponse.json({ error: "Passkey challenge is missing or expired" }, { status: 400 })
         )
       }
+
+      // Delete-and-return consumes the challenge before verification. Only
+      // one concurrent request can receive it, preventing assertion replay.
+      const { data: flow, error: flowError } = await db
+        .from("passkey_authentication_challenges")
+        .delete()
+        .eq("id", flowId)
+        .gt("expires_at", new Date().toISOString())
+        .select("challenge")
+        .maybeSingle()
+
+      if (flowError || !flow) {
+        return clearChallengeCookie(
+          NextResponse.json({ error: "Passkey challenge is missing or expired" }, { status: 400 })
+        )
+      }
+
+      const { data: passkey, error: passkeyError } = await db
+        .from("passkeys")
+        .select("user_id, credential_id, public_key, counter, transports")
+        .eq("credential_id", credential.id)
+        .single()
+
+      if (passkeyError || !passkey) {
+        return clearChallengeCookie(
+          NextResponse.json({ error: "Passkey authentication failed" }, { status: 400 })
+        )
+      }
+
+      const verification = await verifyAuthenticationResponse({
+        response: credential,
+        expectedChallenge: flow.challenge,
+        expectedOrigin: origin,
+        expectedRPID: rpID,
+        credential: {
+          id: passkey.credential_id,
+          publicKey: Buffer.from(passkey.public_key, "base64"),
+          counter: passkey.counter,
+          transports: passkey.transports || [],
+        },
+        requireUserVerification: true,
+      })
+
+      if (!verification.verified) {
+        return clearChallengeCookie(
+          NextResponse.json({ error: "Passkey authentication failed" }, { status: 400 })
+        )
+      }
+
+      const { data: profile } = await db
+        .from("profiles")
+        .select("status")
+        .eq("id", passkey.user_id)
+        .maybeSingle()
+      if (profile?.status === "suspended") {
+        return clearChallengeCookie(
+          NextResponse.json({ error: "Account suspended" }, { status: 403 })
+        )
+      }
+
+      const { error: updateError } = await db
+        .from("passkeys")
+        .update({
+          counter: verification.authenticationInfo.newCounter ?? passkey.counter,
+          last_used_at: new Date().toISOString(),
+        })
+        .eq("credential_id", passkey.credential_id)
+        .eq("user_id", passkey.user_id)
+
+      if (updateError) {
+        return clearChallengeCookie(
+          NextResponse.json({ error: "Passkey state could not be updated" }, { status: 503 })
+        )
+      }
+
+      const { data: authUser, error: userError } = await db.auth.admin.getUserById(passkey.user_id)
+      if (userError || !authUser.user?.email) {
+        return clearChallengeCookie(
+          NextResponse.json({ error: "Passkey account is unavailable" }, { status: 400 })
+        )
+      }
+
+      // Mint a normal Supabase session only after WebAuthn verification. The
+      // one-time magic-link token remains server-side and verifyOtp writes the
+      // standard SSR auth cookies to this response context.
+      const { data: link, error: linkError } = await db.auth.admin.generateLink({
+        type: "magiclink",
+        email: authUser.user.email,
+      })
+      const tokenHash = link.properties?.hashed_token
+      if (linkError || !tokenHash) {
+        return clearChallengeCookie(
+          NextResponse.json({ error: "Unable to create authenticated session" }, { status: 503 })
+        )
+      }
+
+      const supabase = await createClient()
+      const { data: session, error: sessionError } = await supabase.auth.verifyOtp({
+        type: "magiclink",
+        token_hash: tokenHash,
+      })
+      if (sessionError || !session.session || session.user?.id !== passkey.user_id) {
+        await supabase.auth.signOut()
+        return clearChallengeCookie(
+          NextResponse.json({ error: "Unable to create authenticated session" }, { status: 503 })
+        )
+      }
+
+      return clearChallengeCookie(NextResponse.json({ success: true }))
     }
 
     return NextResponse.json({ error: "Invalid action" }, { status: 400 })
-    } catch (err: unknown) {
-      return NextResponse.json(
-        { error: `Authentication error: ${err instanceof Error ? err.message : String(err)}` },
-        { status: 500 }
-      )
-    }
+  } catch (err: unknown) {
+    console.error("[passkey-auth] authentication failed", err)
+    return clearChallengeCookie(
+      NextResponse.json({ error: "Passkey authentication failed" }, { status: 400 })
+    )
+  }
 }

--- a/app/api/auth/passkeys/register/route.ts
+++ b/app/api/auth/passkeys/register/route.ts
@@ -3,113 +3,159 @@ import {
   generateRegistrationOptions,
   verifyRegistrationResponse,
 } from "@simplewebauthn/server"
-import { createClient } from "@/lib/supabase/server"
+import type { RegistrationResponseJSON } from "@simplewebauthn/server"
+import { getAuthenticatedUser, handleAuthError } from "@/lib/auth/server-auth"
+import { createServiceClient } from "@/lib/supabase/service"
+
+const CHALLENGE_COOKIE = "digit_passkey_registration_flow"
+const CHALLENGE_TTL_MS = 5 * 60 * 1000
+
+function webAuthnConfig() {
+  const origin = new URL(process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000")
+  return { origin: origin.origin, rpID: origin.hostname }
+}
+
+function clearChallengeCookie(response: NextResponse) {
+  response.cookies.set(CHALLENGE_COOKIE, "", {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: process.env.NODE_ENV === "production",
+    path: "/api/auth/passkeys/register",
+    maxAge: 0,
+  })
+  return response
+}
 
 export async function POST(req: NextRequest) {
   try {
-    const { action, data } = await req.json()
+    const user = await getAuthenticatedUser()
+    const body = await req.json() as {
+      action?: "start-registration" | "verify-registration"
+      data?: { credential?: RegistrationResponseJSON; deviceName?: string }
+    }
+    const db = createServiceClient()
+    const { origin, rpID } = webAuthnConfig()
 
-    if (action === "start-registration") {
-      const supabase = await createClient()
-      const {
-        data: { user },
-      } = await supabase.auth.getUser()
+    if (body.action === "start-registration") {
+      const { data: existing } = await db
+        .from("passkeys")
+        .select("credential_id")
+        .eq("user_id", user.id)
 
-      if (!user) {
-        return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
-      }
-
-      // Generate registration options
       const options = await generateRegistrationOptions({
-        rpID: process.env.NEXT_PUBLIC_APP_URL?.split("//")[1] || "localhost:3000",
+        rpID,
         rpName: "DigiT",
         userName: user.email || user.id,
         userID: Buffer.from(user.id),
         userDisplayName: user.user_metadata?.full_name || user.email || "User",
+        attestationType: "none",
+        authenticatorSelection: {
+          residentKey: "preferred",
+          userVerification: "required",
+        },
+        excludeCredentials: (existing || []).map((passkey) => ({ id: passkey.credential_id })),
       })
 
-      // Store challenge in session/database temporarily
-      // For now, we'll return it and expect it back in verification
-      return NextResponse.json({
-        options,
-        challenge: options.challenge,
+      const { data: flow, error } = await db
+        .from("passkey_registration_challenges")
+        .insert({
+          user_id: user.id,
+          challenge: options.challenge,
+          expires_at: new Date(Date.now() + CHALLENGE_TTL_MS).toISOString(),
+        })
+        .select("id")
+        .single()
+
+      if (error || !flow) {
+        return NextResponse.json({ error: "Unable to start passkey registration" }, { status: 503 })
+      }
+
+      const response = NextResponse.json({ options })
+      response.cookies.set(CHALLENGE_COOKIE, flow.id, {
+        httpOnly: true,
+        sameSite: "strict",
+        secure: process.env.NODE_ENV === "production",
+        path: "/api/auth/passkeys/register",
+        maxAge: CHALLENGE_TTL_MS / 1000,
       })
+      return response
     }
 
-    if (action === "verify-registration") {
-      const supabase = await createClient()
-      const {
-        data: { user },
-      } = await supabase.auth.getUser()
-
-      if (!user) {
-        return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
-      }
-
-      const { credential, challenge, deviceName } = data
-
-      try {
-        // Verify the credential
-        const verification = await verifyRegistrationResponse({
-          response: credential,
-          expectedChallenge: challenge,
-          expectedOrigin: process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
-          expectedRPID: process.env.NEXT_PUBLIC_APP_URL?.split("//")[1] || "localhost:3000",
-        })
-
-        if (!verification.verified || !verification.registrationInfo) {
-          return NextResponse.json(
-            { error: "Verification failed" },
-            { status: 400 }
-          )
-        }
-
-        // Store passkey in database
-        const { credential: registeredCredential } =
-          verification.registrationInfo
-        const credentialID = registeredCredential.id
-        const publicKey = Buffer.from(
-          registeredCredential.publicKey
-        ).toString("base64")
-
-        const { data: passkey, error } = await supabase
-          .from("passkeys")
-          .insert({
-            user_id: user.id,
-            credential_id: credentialID,
-            public_key: publicKey,
-            counter: registeredCredential.counter,
-            device_name: deviceName || "Unknown Device",
-            transports: credential.response?.transports || [],
-          })
-          .select()
-          .single()
-
-        if (error) {
-          return NextResponse.json(
-            { error: `Failed to save passkey: ${error.message}` },
-            { status: 500 }
-          )
-        }
-
-        return NextResponse.json({
-          success: true,
-          passkey,
-          message: "Passkey registered successfully",
-        })
-      } catch (err: unknown) {
-        return NextResponse.json(
-          { error: `Verification error: ${err instanceof Error ? err.message : String(err)}` },
-          { status: 400 }
+    if (body.action === "verify-registration") {
+      const credential = body.data?.credential
+      const flowId = req.cookies.get(CHALLENGE_COOKIE)?.value
+      if (!credential || !flowId) {
+        return clearChallengeCookie(
+          NextResponse.json({ error: "Registration challenge is missing or expired" }, { status: 400 })
         )
       }
+
+      // Consume the challenge atomically and bind it to the current session
+      // user. A different account cannot finish another account's ceremony.
+      const { data: flow, error: flowError } = await db
+        .from("passkey_registration_challenges")
+        .delete()
+        .eq("id", flowId)
+        .eq("user_id", user.id)
+        .gt("expires_at", new Date().toISOString())
+        .select("challenge")
+        .maybeSingle()
+
+      if (flowError || !flow) {
+        return clearChallengeCookie(
+          NextResponse.json({ error: "Registration challenge is missing or expired" }, { status: 400 })
+        )
+      }
+
+      const verification = await verifyRegistrationResponse({
+        response: credential,
+        expectedChallenge: flow.challenge,
+        expectedOrigin: origin,
+        expectedRPID: rpID,
+        requireUserVerification: true,
+      })
+
+      if (!verification.verified || !verification.registrationInfo) {
+        return clearChallengeCookie(
+          NextResponse.json({ error: "Passkey registration failed" }, { status: 400 })
+        )
+      }
+
+      const { credential: registeredCredential } = verification.registrationInfo
+      const { data: passkey, error } = await db
+        .from("passkeys")
+        .insert({
+          user_id: user.id,
+          credential_id: registeredCredential.id,
+          public_key: Buffer.from(registeredCredential.publicKey).toString("base64"),
+          counter: registeredCredential.counter,
+          device_name: body.data?.deviceName?.trim().slice(0, 100) || "Unknown Device",
+          transports: credential.response.transports || [],
+        })
+        .select("id, device_name, created_at")
+        .single()
+
+      if (error || !passkey) {
+        return clearChallengeCookie(
+          NextResponse.json({ error: "Unable to save passkey" }, { status: 409 })
+        )
+      }
+
+      return clearChallengeCookie(NextResponse.json({
+        success: true,
+        passkey,
+        message: "Passkey registered successfully",
+      }))
     }
 
     return NextResponse.json({ error: "Invalid action" }, { status: 400 })
-    } catch (err: unknown) {
-      return NextResponse.json(
-        { error: `Registration error: ${err instanceof Error ? err.message : String(err)}` },
-        { status: 500 }
-      )
+  } catch (error) {
+    if (error instanceof Error && ["Unauthorized", "Suspended"].includes(error.message)) {
+      return handleAuthError(error)
     }
+    console.error("[passkey-registration] registration failed", error)
+    return clearChallengeCookie(
+      NextResponse.json({ error: "Passkey registration failed" }, { status: 400 })
+    )
+  }
 }

--- a/app/api/auth/sign-up/route.ts
+++ b/app/api/auth/sign-up/route.ts
@@ -1,19 +1,10 @@
 "use server"
 
 import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
 import { createServiceClient } from "@/lib/supabase/service"
-import { startTrial } from "@/lib/billing/subscription-lifecycle"
-import { logAuthEvent } from "@/lib/auth/audit"
-import { v4 as uuidv4 } from "uuid"
-import { createHash } from "node:crypto"
-
-function generateSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "")
-    .substring(0, 50)
-}
+import { checkTenantRateLimit } from "@/lib/multitenant/rate-limit"
+import { getClientIp } from "@/lib/auth/audit"
 
 function validatePassword(password: string): { valid: boolean; error?: string } {
   if (password.length < 8) return { valid: false, error: "Password must be at least 8 characters" }
@@ -25,7 +16,8 @@ function validatePassword(password: string): { valid: boolean; error?: string } 
 }
 
 // POST /api/auth/sign-up
-// Server-side sign-up that auto-confirms email and creates a trial.
+// Starts Supabase's email-verification signup flow. Tenant provisioning happens
+// only after the callback has verified the email and established a session.
 export async function POST(request: Request) {
   try {
     const { email, password, fullName, companyName } = await request.json()
@@ -45,18 +37,39 @@ export async function POST(request: Request) {
       )
     }
 
-    const db = createServiceClient()
-    const organizationId = uuidv4()
-    const slug = generateSlug(companyName || email.split("@")[0])
+    const normalizedEmail = String(email).trim().toLowerCase()
+    const clientIp = getClientIp(request.headers) ?? "unknown"
+    const [ipLimited, emailLimited] = await Promise.all([
+      checkTenantRateLimit(`signup-ip:${clientIp}`, 10, 60),
+      checkTenantRateLimit(`signup-email:${normalizedEmail}`, 3, 60),
+    ])
 
-    // 1. Create auth user with email auto-confirmed
-    const { data: authData, error: authError } = await db.auth.admin.createUser({
-      email,
+    if (ipLimited || emailLimited) {
+      return NextResponse.json(
+        { error: "Too many signup attempts. Please try again later." },
+        { status: 429 }
+      )
+    }
+
+    const supabase = await createClient()
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL
+    if (!siteUrl) {
+      console.error("[auth] Missing canonical site URL for signup verification")
+      return NextResponse.json({ error: "Signup is temporarily unavailable" }, { status: 503 })
+    }
+
+    const emailRedirectTo = new URL("/auth/callback", siteUrl)
+    emailRedirectTo.searchParams.set("next", "/")
+
+    const { data: authData, error: authError } = await supabase.auth.signUp({
+      email: normalizedEmail,
       password,
-      email_confirm: true,
-      user_metadata: {
-        full_name: fullName,
-        company_name: companyName,
+      options: {
+        emailRedirectTo: emailRedirectTo.toString(),
+        data: {
+          full_name: fullName,
+          company_name: companyName,
+        },
       },
     })
 
@@ -68,116 +81,27 @@ export async function POST(request: Request) {
       )
     }
 
-    const userId = authData.user.id
-
-    // 2. Create organization
-    const { error: orgError } = await db.from("organizations").insert({
-      id: organizationId,
-      name: companyName || email.split("@")[1] || "My Organization",
-      slug,
-      created_at: new Date().toISOString(),
-    })
-
-    if (orgError) {
-      console.error("[v0] Error creating organization:", orgError)
+    // Supabase returns a session immediately when email confirmation is
+    // disabled at the project level. That configuration would bypass the
+    // ownership check this endpoint promises, so remove the just-created
+    // account and fail closed instead of provisioning it.
+    if (authData.session) {
+      await supabase.auth.signOut()
+      const db = createServiceClient()
+      const { error: cleanupError } = await db.auth.admin.deleteUser(authData.user.id)
+      if (cleanupError) {
+        console.error("[auth] Failed to clean up unverified signup:", cleanupError)
+      }
       return NextResponse.json(
-        { error: "Failed to create organization" },
-        { status: 500 }
+        { error: "Signup requires email verification, but it is not enabled" },
+        { status: 503 }
       )
     }
-
-    // 3. Create profile
-    const { error: profileError } = await db.from("profiles").insert({
-      id: userId,
-      email,
-      full_name: fullName || email.split("@")[0],
-      organization_id: organizationId,
-      role: "admin",
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-    })
-
-    if (profileError) {
-      console.error("[v0] Error creating profile:", profileError)
-      return NextResponse.json(
-        { error: "Failed to create profile" },
-        { status: 500 }
-      )
-    }
-
-    // 4. Start trial
-    const trialResult = await startTrial(organizationId, "professional", userId)
-    if (!trialResult.success) {
-      return NextResponse.json(
-        { error: "Failed to start trial" },
-        { status: 500 }
-      )
-    }
-
-    // 5. Initialize onboarding progress
-    const { error: onboardingError } = await db.from("onboarding_progress").insert({
-      id: uuidv4(),
-      organization_id: organizationId,
-      current_step: 0,
-      total_steps: 5,
-      setup_completed: false,
-      created_at: new Date().toISOString(),
-    })
-
-    if (onboardingError) {
-      console.error("[v0] Error creating onboarding progress:", onboardingError)
-    }
-
-    // 6. Create API key
-    const apiKeyId = uuidv4()
-    const rawKey = `dk_${uuidv4().replace(/-/g, "")}${organizationId.substring(0, 8)}`
-    const keyPrefix = rawKey.substring(0, 12)
-
-    const { error: apiKeyError } = await db.from("api_keys").insert({
-      id: apiKeyId,
-      organization_id: organizationId,
-      name: "Default API Key",
-      key_prefix: keyPrefix,
-      key_hash: createHash("sha256").update(rawKey).digest("hex"),
-      scopes: ["read", "write"],
-      created_at: new Date().toISOString(),
-    })
-
-    if (apiKeyError) {
-      console.error("[v0] Error creating API key:", apiKeyError)
-    }
-
-    // 7. Initialize usage tracking
-    const now = new Date()
-    const periodStart = new Date(now.getFullYear(), now.getMonth(), 1)
-    const periodEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0)
-
-    const { error: usageError } = await db.from("usage").insert({
-      id: uuidv4(),
-      organization_id: organizationId,
-      metric: "api_calls",
-      value: 0,
-      period_start: periodStart.toISOString(),
-      period_end: periodEnd.toISOString(),
-      created_at: now.toISOString(),
-    })
-
-    if (usageError) {
-      console.error("[v0] Error creating usage tracking:", usageError)
-    }
-
-    await logAuthEvent({
-      action: "auth.trial_created",
-      userId,
-      organizationId,
-      metadata: { email, companyName, fullName },
-    })
 
     return NextResponse.json({
       success: true,
-      userId,
-      organizationId,
-      message: "Account created successfully",
+      requiresEmailVerification: true,
+      message: "Check your email to verify your account",
     })
   } catch (error) {
     console.error("[v0] Error in sign-up:", error)

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,24 +1,35 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { createServiceClient } from '@/lib/supabase/service'
+import { createClient } from '@/lib/supabase/server'
+import { checkTenantRateLimit } from '@/lib/multitenant/rate-limit'
+import { getClientIp } from '@/lib/auth/audit'
 
 const feedbackSchema = z.object({
   rating: z.number().min(1).max(5),
-  comments: z.string().optional(),
-  userId: z.string().optional(),
+  comments: z.string().trim().max(5000).optional(),
 })
 
 export async function POST(request: Request) {
   try {
+    const clientIp = getClientIp(request.headers) ?? 'unknown'
+    const limited = await checkTenantRateLimit(`feedback-ip:${clientIp}`, 100, 10)
+    if (limited) return limited
+
     const body = await request.json()
-    const { rating, comments, userId } = feedbackSchema.parse(body)
+    const { rating, comments } = feedbackSchema.parse(body)
+
+    // Feedback may be anonymous, but a caller must never be able to attribute
+    // it to another account. Use only a session identity verified by Supabase.
+    const auth = await createClient()
+    const { data: { user } } = await auth.auth.getUser()
 
     const supabase = createServiceClient()
 
     const { error } = await supabase.from('feedback').insert({
       rating,
       comments: comments || null,
-      user_id: userId || null,
+      user_id: user?.id || null,
     })
 
     if (error) {

--- a/app/api/ingestion/email/route.ts
+++ b/app/api/ingestion/email/route.ts
@@ -1,11 +1,23 @@
 "use strict";
+import type { NextRequest } from "next/server";
+import { isAuthorizedCronRequest } from "@/lib/cron/auth";
 import { processEmails } from "../../../../lib/ingestion/email";
 
 /**
  * POST /api/ingestion/email
  * Triggers email ingestion pipeline
  */
-export async function POST() {
+export async function POST(request: NextRequest) {
+    if (!isAuthorizedCronRequest(request)) {
+        return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // This legacy pipeline still uses placeholder IMAP data. Never fabricate
+    // ingestion results in a production environment.
+    if (process.env.NODE_ENV === "production") {
+        return Response.json({ error: "Legacy email ingestion is disabled" }, { status: 503 });
+    }
+
     try {
         const results = await processEmails();
         return new Response(JSON.stringify(results), {

--- a/app/api/ingestion/whatsapp/route.ts
+++ b/app/api/ingestion/whatsapp/route.ts
@@ -1,11 +1,23 @@
 "use strict";
+import type { NextRequest } from "next/server";
+import { isAuthorizedCronRequest } from "@/lib/cron/auth";
 import { handleWhatsAppWebhook } from "../../../../lib/ingestion/whatsapp";
 
 /**
  * POST /api/ingestion/whatsapp
  * Handles WhatsApp webhook for message ingestion
  */
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
+    if (!isAuthorizedCronRequest(request)) {
+        return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // The handler below is a legacy mock. The signed Meta webhook lives at
+    // /api/v1/operations/whatsapp-webhook.
+    if (process.env.NODE_ENV === "production") {
+        return Response.json({ error: "Legacy WhatsApp ingestion is disabled" }, { status: 503 });
+    }
+
     try {
         const message = await request.json();
         const result = await handleWhatsAppWebhook(message);

--- a/app/api/notifications/unread-count/route.ts
+++ b/app/api/notifications/unread-count/route.ts
@@ -4,29 +4,24 @@ import { extractTenantContext } from "@/lib/multitenant/context.server"
 import { logger } from "@/lib/logging"
 
 export async function GET() {
-  // TODO: re-enable auth check once session/cookie issues are resolved
-  // const ctx = await extractTenantContext()
-  // if (!ctx) {
-  //   return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
-  // }
+  const ctx = await extractTenantContext()
+  if (!ctx) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
 
   try {
-    // const supabase = await createClient()
-    // const { data, error } = await supabase
-    //   .from("notifications")
-    //   .select("id", { count: "exact", head: true })
-    //   .eq("organization_id", ctx.organizationId)
-    //   .eq("user_id", ctx.userId)
-    //   .is("read_at", null)
+    const supabase = await createClient()
+    const { count, error } = await supabase
+      .from("notifications")
+      .select("id", { count: "exact", head: true })
+      .eq("organization_id", ctx.organizationId)
+      .eq("user_id", ctx.userId)
+      .is("read_at", null)
 
-    // if (error) {
-    //   logger.logError("[v0] unread count error:", { error: error.message })
-    //   return NextResponse.json({ count: 0 })
-    // }
-
-    // return NextResponse.json({ count: data?.length ?? 0 })
-    return NextResponse.json({ count: 0 })
-  } catch {
-    return NextResponse.json({ count: 0 })
+    if (error) throw error
+    return NextResponse.json({ count: count ?? 0 })
+  } catch (error) {
+    logger.logError("[notifications] unread count failed", { error })
+    return NextResponse.json({ error: "Unable to load notifications" }, { status: 500 })
   }
 }

--- a/app/api/operations/upload/route.ts
+++ b/app/api/operations/upload/route.ts
@@ -9,6 +9,74 @@ import * as xlsx from 'xlsx'
 
 export const maxDuration = 30
 
+const MAX_FILE_BYTES = 10 * 1024 * 1024
+const MAX_JSON_BYTES = 1024 * 1024
+const MAX_MULTIPART_BYTES = MAX_FILE_BYTES + 256 * 1024
+const MAX_SPREADSHEET_ROWS = 10_000
+const MAX_SPREADSHEET_CELLS = 100_000
+
+const ALLOWED_FILE_TYPES: Record<string, readonly string[]> = {
+  '.txt': ['text/plain', 'application/octet-stream'],
+  '.md': ['text/markdown', 'text/plain', 'application/octet-stream'],
+  '.json': ['application/json', 'text/json', 'text/plain', 'application/octet-stream'],
+  '.csv': ['text/csv', 'application/csv', 'application/vnd.ms-excel', 'text/plain', 'application/octet-stream'],
+  '.xlsx': ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/octet-stream'],
+  '.xls': ['application/vnd.ms-excel', 'application/octet-stream'],
+  '.pdf': ['application/pdf', 'application/octet-stream'],
+  '.png': ['image/png', 'application/octet-stream'],
+  '.jpg': ['image/jpeg', 'application/octet-stream'],
+  '.jpeg': ['image/jpeg', 'application/octet-stream'],
+  '.webp': ['image/webp', 'application/octet-stream'],
+}
+
+class UploadError extends Error {
+  constructor(message: string, readonly status: 413 | 415) {
+    super(message)
+  }
+}
+
+function fileExtension(name: string) {
+  const match = name.toLowerCase().match(/\.[a-z0-9]+$/)
+  return match?.[0] ?? ''
+}
+
+function safeFilename(name: string) {
+  const basename = name.replace(/\\/g, '/').split('/').pop() || 'upload'
+  const sanitized = basename
+    .normalize('NFKC')
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/[^a-zA-Z0-9._-]+/g, '_')
+    .replace(/^\.+/, '')
+    .slice(0, 180)
+  return sanitized || 'upload'
+}
+
+function validateFile(file: File) {
+  if (file.size > MAX_FILE_BYTES) {
+    throw new UploadError(`File exceeds the ${MAX_FILE_BYTES / 1024 / 1024} MB limit`, 413)
+  }
+
+  const extension = fileExtension(file.name)
+  const allowedMimeTypes = ALLOWED_FILE_TYPES[extension]
+  const mimeType = (file.type || 'application/octet-stream').toLowerCase()
+  if (!allowedMimeTypes || !allowedMimeTypes.includes(mimeType)) {
+    throw new UploadError('Unsupported file type', 415)
+  }
+}
+
+function validateSpreadsheetSize(sheet: xlsx.WorkSheet | undefined) {
+  if (!sheet?.['!ref']) return
+  const range = xlsx.utils.decode_range(sheet['!ref'])
+  const rows = range.e.r - range.s.r + 1
+  const columns = range.e.c - range.s.c + 1
+  if (rows > MAX_SPREADSHEET_ROWS || rows * columns > MAX_SPREADSHEET_CELLS) {
+    throw new UploadError(
+      `Spreadsheet exceeds ${MAX_SPREADSHEET_ROWS} rows or ${MAX_SPREADSHEET_CELLS} cells`,
+      413
+    )
+  }
+}
+
 async function parseFile(file: File): Promise<{ content: string; rawData: unknown[] | null; mimeType: string; sizeBytes: number }> {
   const mimeType = file.type || 'application/octet-stream'
   const sizeBytes = file.size
@@ -32,15 +100,16 @@ async function parseFile(file: File): Promise<{ content: string; rawData: unknow
   // CSV
   if (name.endsWith('.csv')) {
     const text = await file.text()
-    const rows = text.split(/\r?\n/).filter(Boolean)
-    if (rows.length === 0) return { content: text, rawData: [], mimeType: 'text/csv', sizeBytes }
-    const headers = rows[0].split(',').map(h => h.trim())
-    const data = rows.slice(1).map(row => {
-      const values = row.split(',')
-      const obj: Record<string, string> = {}
-      headers.forEach((h, i) => { obj[h] = values[i]?.trim() ?? '' })
-      return obj
-    })
+    // A naive `row.split(',')` breaks on quoted fields that contain commas
+    // (or embedded newlines/escaped quotes), silently shifting every column
+    // after one and corrupting the stats generate-report computes from
+    // raw_data. xlsx is already a dependency (used for the Excel branch
+    // below) and its CSV reader is quote-aware, so reuse it here instead of
+    // pulling in a new parsing library for this one file.
+    const workbook = xlsx.read(text, { type: 'string' })
+    const firstSheet = workbook.Sheets[workbook.SheetNames[0]]
+    validateSpreadsheetSize(firstSheet)
+    const data = firstSheet ? xlsx.utils.sheet_to_json(firstSheet, { defval: '' }) : []
     return { content: text, rawData: data, mimeType: 'text/csv', sizeBytes }
   }
 
@@ -49,7 +118,8 @@ async function parseFile(file: File): Promise<{ content: string; rawData: unknow
     const buffer = await file.arrayBuffer()
     const workbook = xlsx.read(buffer, { type: 'array' })
     const firstSheet = workbook.Sheets[workbook.SheetNames[0]]
-    const data = xlsx.utils.sheet_to_json(firstSheet)
+    validateSpreadsheetSize(firstSheet)
+    const data = firstSheet ? xlsx.utils.sheet_to_json(firstSheet) : []
     return { content: '', rawData: data, mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', sizeBytes }
   }
 
@@ -66,7 +136,7 @@ async function parseFile(file: File): Promise<{ content: string; rawData: unknow
     }
   }
 
-  // Fallback: anything else (images, docx, zip, ...) is binary. Decoding it
+  // Allowed images are binary. Decoding them
   // via file.text() would corrupt it and can embed NUL bytes that Postgres
   // text columns reject outright, so just record it without extracted content.
   return { content: '', rawData: null, mimeType: mimeType || 'application/octet-stream', sizeBytes }
@@ -80,6 +150,13 @@ export async function POST(request: Request) {
     }
 
     const contentType = request.headers.get('content-type') || ''
+    const contentLength = Number(request.headers.get('content-length'))
+    if (Number.isFinite(contentLength)) {
+      const requestLimit = contentType.includes('multipart/form-data') ? MAX_MULTIPART_BYTES : MAX_JSON_BYTES
+      if (contentLength > requestLimit) {
+        return NextResponse.json({ error: 'Request payload too large' }, { status: 413 })
+      }
+    }
     const db = createServiceClient()
 
     let name: string
@@ -97,13 +174,14 @@ export async function POST(request: Request) {
       if (!file) {
         return NextResponse.json({ error: 'No file provided' }, { status: 400 })
       }
-      name = file.name
+      validateFile(file)
+      name = safeFilename(file.name)
       const parsed = await parseFile(file)
       content = parsed.content
       rawData = parsed.rawData
       mimeType = parsed.mimeType
       sizeBytes = parsed.sizeBytes
-      metadata = { source: 'operations_upload', filename: file.name, mime_type: mimeType }
+      metadata = { source: 'operations_upload', filename: name, mime_type: mimeType }
       // File/Blob can be read more than once -- safe to read again here for
       // the raw bytes now that parseFile() has already consumed it for text.
       fileBuffer = Buffer.from(await file.arrayBuffer())
@@ -116,9 +194,13 @@ export async function POST(request: Request) {
       content = String(body.text)
       type = 'text'
       sizeBytes = new TextEncoder().encode(content).length
+      if (sizeBytes > MAX_JSON_BYTES) {
+        return NextResponse.json({ error: 'Text payload too large' }, { status: 413 })
+      }
+      name = safeFilename(String(body.name))
       metadata = { source: 'operations_upload', input_type: 'text' }
     } else {
-      return NextResponse.json({ error: 'Unsupported content type' }, { status: 400 })
+      return NextResponse.json({ error: 'Unsupported content type' }, { status: 415 })
     }
 
     const insert: Record<string, unknown> = {
@@ -195,6 +277,9 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ success: true, document: responseDoc, document_id: doc.id })
   } catch (error) {
+    if (error instanceof UploadError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
     console.error('[operations/upload] error:', error)
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Upload failed' },

--- a/app/api/v1/api-keys/route.ts
+++ b/app/api/v1/api-keys/route.ts
@@ -1,0 +1,105 @@
+import { withAuth } from "@/lib/auth/with-auth"
+import { createServiceClient } from "@/lib/supabase/service"
+import { v4 as uuidv4 } from "uuid"
+import { createHash } from "node:crypto"
+import { logAuthEvent, getClientIp } from "@/lib/auth/audit"
+import { NextResponse } from "next/server"
+
+// Backs app/(dashboard)/settings/page.tsx's API Keys panel. The table
+// (api_keys) and RLS policy live in
+// supabase/migrations/20260817000000_api_keys.sql.
+
+function canManageApiKeys(role: string) {
+  return role === "owner" || role === "admin"
+}
+
+export const GET = withAuth(async (req, { organizationId, role }) => {
+  if (!canManageApiKeys(role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const supabase = createServiceClient()
+
+  const { data: keys, error } = await supabase
+    .from("api_keys")
+    .select("id, name, key_prefix, scopes, created_at, last_used_at")
+    .eq("organization_id", organizationId)
+    .order("created_at", { ascending: false })
+
+  if (error) {
+    return NextResponse.json({ keys: [] })
+  }
+
+  return NextResponse.json({ keys: keys || [] })
+})
+
+export const POST = withAuth(async (req, { organizationId, userId, role }) => {
+  if (!canManageApiKeys(role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const { name, scopes } = await req.json()
+
+  const apiKeyId = uuidv4()
+  const rawKey = `dk_${uuidv4().replace(/-/g, "")}${organizationId.substring(0, 8)}`
+  const keyPrefix = rawKey.substring(0, 12)
+
+  const supabase = createServiceClient()
+
+  const { error } = await supabase.from("api_keys").insert({
+    id: apiKeyId,
+    organization_id: organizationId,
+    name: name || "API Key",
+    key_prefix: keyPrefix,
+    key_hash: createHash("sha256").update(rawKey).digest("hex"),
+    scopes: scopes || ["read", "write"],
+    created_by: userId,
+  })
+
+  if (error) {
+    return NextResponse.json({ error: "Failed to generate key" }, { status: 500 })
+  }
+
+  await logAuthEvent({
+    action: "auth.api_key_generated",
+    userId,
+    organizationId: organizationId ?? undefined,
+    resourceId: apiKeyId,
+    ipAddress: getClientIp(req.headers),
+  })
+
+  return NextResponse.json({ key: rawKey, id: apiKeyId, name: name || "API Key" }, { status: 201 })
+})
+
+export const DELETE = withAuth(async (req, { organizationId, userId, role }) => {
+  if (!canManageApiKeys(role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const { id } = await req.json()
+
+  if (!id) {
+    return NextResponse.json({ error: "Key ID is required" }, { status: 400 })
+  }
+
+  const supabase = createServiceClient()
+  const { error } = await supabase
+    .from("api_keys")
+    .delete()
+    .eq("id", id)
+    .eq("organization_id", organizationId)
+
+  if (error) {
+    return NextResponse.json({ error: "Failed to delete key" }, { status: 500 })
+  }
+
+  await logAuthEvent({
+    action: "auth.api_key_revoked",
+    userId,
+    organizationId: organizationId ?? undefined,
+    resourceId: id,
+    ipAddress: getClientIp(req.headers),
+  })
+
+  return NextResponse.json({ success: true })
+})

--- a/app/api/v1/auth/passwordless/request/route.ts
+++ b/app/api/v1/auth/passwordless/request/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { sendMagicLink } from '@/lib/auth/passwordless/service'
 import { PasswordlessError } from '@/lib/auth/passwordless/types'
+import { getClientIp } from '@/lib/auth/audit'
+import { checkTenantRateLimit } from '@/lib/multitenant/rate-limit'
 
 export async function POST(request: NextRequest) {
   try {
@@ -8,6 +10,10 @@ export async function POST(request: NextRequest) {
     if (!email || typeof email !== 'string') {
       return NextResponse.json({ error: 'email is required' }, { status: 400 })
     }
+
+    const ip = getClientIp(request.headers) ?? 'unknown'
+    const limited = await checkTenantRateLimit(`passwordless-request-ip:${ip}`, 30, 5)
+    if (limited) return limited
 
     await sendMagicLink({ email, redirectTo })
     return NextResponse.json({ success: true })

--- a/app/api/v1/auth/passwordless/verify/route.ts
+++ b/app/api/v1/auth/passwordless/verify/route.ts
@@ -2,6 +2,8 @@ import { NextResponse, type NextRequest } from 'next/server'
 import { verifyMagicLink } from '@/lib/auth/passwordless/service'
 import { createClient } from '@/lib/supabase/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getClientIp } from '@/lib/auth/audit'
+import { checkTenantRateLimit } from '@/lib/multitenant/rate-limit'
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +13,14 @@ export async function POST(request: NextRequest) {
     }
 
     const normalizedEmail = String(email).trim().toLowerCase()
+    const ip = getClientIp(request.headers) ?? 'unknown'
+    const [ipLimited, emailLimited] = await Promise.all([
+      checkTenantRateLimit(`passwordless-verify-ip:${ip}`, 100, 10),
+      checkTenantRateLimit(`passwordless-verify-email:${normalizedEmail}`, 20, 5),
+    ])
+    if (ipLimited) return ipLimited
+    if (emailLimited) return emailLimited
+
     const userId = await verifyMagicLink(String(passcode), normalizedEmail)
     if (!userId) {
       return NextResponse.json({ error: 'Invalid or expired passcode' }, { status: 400 })

--- a/app/api/v1/auth/passwordless/verify/route.ts
+++ b/app/api/v1/auth/passwordless/verify/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { verifyMagicLink } from '@/lib/auth/passwordless/service'
+import { createClient } from '@/lib/supabase/server'
+import { createServiceClient } from '@/lib/supabase/service'
 
 export async function POST(request: NextRequest) {
   try {
@@ -8,13 +10,47 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'email and passcode are required' }, { status: 400 })
     }
 
-    const userId = await verifyMagicLink(passcode, email)
+    const normalizedEmail = String(email).trim().toLowerCase()
+    const userId = await verifyMagicLink(String(passcode), normalizedEmail)
     if (!userId) {
       return NextResponse.json({ error: 'Invalid or expired passcode' }, { status: 400 })
     }
 
+    // The custom passcode proves control of the email, but returning a user ID
+    // is not authentication. Exchange that proof for a standard Supabase SSR
+    // session, keeping the generated one-time token entirely server-side.
+    const db = createServiceClient()
+    const { data: authUser, error: userError } = await db.auth.admin.getUserById(userId)
+    if (
+      userError ||
+      !authUser.user?.email ||
+      authUser.user.email.toLowerCase() !== normalizedEmail
+    ) {
+      return NextResponse.json({ error: 'Unable to authenticate account' }, { status: 503 })
+    }
+
+    const { data: link, error: linkError } = await db.auth.admin.generateLink({
+      type: 'magiclink',
+      email: authUser.user.email,
+    })
+    const tokenHash = link.properties?.hashed_token
+    if (linkError || !tokenHash || link.user?.id !== userId) {
+      return NextResponse.json({ error: 'Unable to create authenticated session' }, { status: 503 })
+    }
+
+    const supabase = await createClient()
+    const { data: session, error: sessionError } = await supabase.auth.verifyOtp({
+      type: 'magiclink',
+      token_hash: tokenHash,
+    })
+    if (sessionError || !session.session || session.user?.id !== userId) {
+      await supabase.auth.signOut()
+      return NextResponse.json({ error: 'Unable to create authenticated session' }, { status: 503 })
+    }
+
     return NextResponse.json({ userId })
-  } catch {
+  } catch (error) {
+    console.error('[passwordless/verify] verification failed', error)
     return NextResponse.json({ error: 'Failed to verify passcode' }, { status: 500 })
   }
 }

--- a/app/api/v1/auth/webauthn/register/route.ts
+++ b/app/api/v1/auth/webauthn/register/route.ts
@@ -1,16 +1,20 @@
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { createWebAuthnRegistrationOptions } from '@/lib/auth/webauthn/service'
+import { getAuthenticatedUser, handleAuthError } from '@/lib/auth/server-auth'
 
-export async function POST(request: NextRequest) {
+export async function POST() {
   try {
-    const { email, userId } = await request.json()
-    if (!email || !userId) {
-      return NextResponse.json({ error: 'email and userId are required' }, { status: 400 })
+    const user = await getAuthenticatedUser()
+    if (!user.email) {
+      return NextResponse.json({ error: 'The authenticated account does not have an email address' }, { status: 400 })
     }
 
-    const options = await createWebAuthnRegistrationOptions(userId, email)
+    const options = await createWebAuthnRegistrationOptions(user.id, user.email)
     return NextResponse.json(options)
-  } catch {
+  } catch (error) {
+    if (error instanceof Error && ['Unauthorized', 'Suspended'].includes(error.message)) {
+      return handleAuthError(error)
+    }
     return NextResponse.json({ error: 'Failed to start device registration' }, { status: 500 })
   }
 }

--- a/app/api/v1/auth/webauthn/verify/route.ts
+++ b/app/api/v1/auth/webauthn/verify/route.ts
@@ -1,20 +1,25 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { verifyWebAuthnRegistrationResponse, registerWebAuthnCredential } from '@/lib/auth/webauthn/service'
+import { getAuthenticatedUser, handleAuthError } from '@/lib/auth/server-auth'
 
 export async function POST(request: NextRequest) {
   try {
-    const { email, userId, credential, deviceName } = await request.json()
-    if (!email || !userId || !credential) {
-      return NextResponse.json({ error: 'email, userId, and credential are required' }, { status: 400 })
+    const user = await getAuthenticatedUser()
+    const { credential, deviceName } = await request.json()
+    if (!user.email) {
+      return NextResponse.json({ error: 'The authenticated account does not have an email address' }, { status: 400 })
+    }
+    if (!credential) {
+      return NextResponse.json({ error: 'credential is required' }, { status: 400 })
     }
 
-    const result = await verifyWebAuthnRegistrationResponse(email, credential)
+    const result = await verifyWebAuthnRegistrationResponse(user.email, credential)
     if (!result.verified || !result.credential) {
       return NextResponse.json({ error: result.error || 'Verification failed' }, { status: 400 })
     }
 
     const saved = await registerWebAuthnCredential({
-      userId,
+      userId: user.id,
       credential: {
         id: result.credential.id,
         publicKey: result.credential.publicKey,
@@ -30,7 +35,10 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.json({ success: true, counter: result.credential.counter })
-  } catch {
+  } catch (error) {
+    if (error instanceof Error && ['Unauthorized', 'Suspended'].includes(error.message)) {
+      return handleAuthError(error)
+    }
     return NextResponse.json({ error: 'Failed to verify device' }, { status: 500 })
   }
 }

--- a/app/api/v1/compliance/esignatures/route.ts
+++ b/app/api/v1/compliance/esignatures/route.ts
@@ -11,20 +11,19 @@ export const GET = withAuth(async (req: NextRequest, { organizationId }) => {
   const status = req.nextUrl.searchParams.get("status") as SignatureRequest["status"] | null
   const requests = await listSignatureRequests(organizationId, status ?? undefined)
   return NextResponse.json({ requests })
-})
+}, { requireAny: ["esignatures:read", "compliance:read"] })
 
 // POST /api/v1/compliance/esignatures
 export const POST = withAuth(async (req: NextRequest, { organizationId, userId }) => {
-  const { documentId, documentName, signerEmail, signerName, signerPhone, message, expiresInDays } = await req.json()
+  const { documentId, signerEmail, signerName, signerPhone, message, expiresInDays } = await req.json()
 
-  if (!documentId || !documentName || !signerEmail) {
-    return NextResponse.json({ error: "documentId, documentName, and signerEmail are required" }, { status: 400 })
+  if (!documentId || !signerEmail) {
+    return NextResponse.json({ error: "documentId and signerEmail are required" }, { status: 400 })
   }
 
   const request = await createSignatureRequest(
     organizationId,
     documentId,
-    documentName,
     userId,
     signerEmail,
     signerName ?? null,
@@ -48,4 +47,4 @@ export const POST = withAuth(async (req: NextRequest, { organizationId, userId }
   )
 
   return NextResponse.json({ request })
-})
+}, { requireAny: ["esignatures:write", "compliance:write"] })

--- a/app/api/v1/identity/liveness/route.ts
+++ b/app/api/v1/identity/liveness/route.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from "next/server"
 import { logger } from "@/lib/logging"
+import { getAuthenticatedUser, handleAuthError } from "@/lib/auth/server-auth"
 
 /**
  * Mock liveness detection API
  */
 export async function POST(request: Request) {
   try {
+    await getAuthenticatedUser()
+
     const { image } = await request.json()
     
     if (!image) {
@@ -15,14 +18,25 @@ export async function POST(request: Request) {
       )
     }
     
-    // Simulate liveness detection
+    if (process.env.NODE_ENV === "production") {
+      return NextResponse.json(
+        { error: "Liveness verification provider is not configured" },
+        { status: 503 }
+      )
+    }
+
+    // Explicit development-only demo result. It must never be interpreted as
+    // an actual identity-verification decision.
     const isLive = Math.random() > 0.1 // 90% chance of passing
     const confidence = isLive ? 0.95 : 0.3
     
     logger.logInfo("[liveness] Mock liveness check", { isLive, confidence })
     
-    return NextResponse.json({ live: isLive, confidence })
+    return NextResponse.json({ live: isLive, confidence, simulated: true })
   } catch (err) {
+    if (err instanceof Error && ["Unauthorized", "Suspended"].includes(err.message)) {
+      return handleAuthError(err)
+    }
     logger.logError("[liveness] Liveness check failed:", { error: err })
     return NextResponse.json(
       { error: "Liveness check failed" },

--- a/app/api/v1/intelligence/briefing/route.ts
+++ b/app/api/v1/intelligence/briefing/route.ts
@@ -1,28 +1,72 @@
 import { NextResponse } from "next/server"
 import { createServiceClient } from "@/lib/supabase/service"
+import { getAuthenticatedUser, getOrganizationId, handleAuthError } from "@/lib/auth/server-auth"
+import { z } from "zod"
+
+const briefingSchema = z.object({
+  content: z.string().trim().min(1).max(50_000).optional(),
+})
 
 export async function GET() {
-  return NextResponse.json({
-    summary: "No briefings available yet.",
-    date: new Date().toISOString().split("T")[0],
-    metrics: [],
-    actionItems: [],
-    topFindings: [],
-    causalChains: [],
-  })
+  try {
+    const user = await getAuthenticatedUser()
+    const organizationId = await getOrganizationId(user.id)
+    const db = createServiceClient()
+    const { data, error } = await db
+      .from("intelligence_briefings")
+      .select("id, date, summary, content, metrics, action_items, generated_at")
+      .eq("organization_id", organizationId)
+      .order("generated_at", { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    if (error) throw error
+    if (data) {
+      return NextResponse.json({
+        ...data,
+        summary: data.summary || data.content,
+        actionItems: data.action_items || [],
+        topFindings: [],
+        causalChains: [],
+      })
+    }
+
+    return NextResponse.json({
+      summary: "No briefings available yet.",
+      date: new Date().toISOString().split("T")[0],
+      metrics: [],
+      actionItems: [],
+      topFindings: [],
+      causalChains: [],
+    })
+  } catch (error) {
+    return handleAuthError(error as Error)
+  }
 }
 
 export async function POST(request: Request) {
   try {
-    const body = await request.json()
+    const user = await getAuthenticatedUser()
+    const organizationId = await getOrganizationId(user.id)
+    const parsed = briefingSchema.safeParse(await request.json().catch(() => ({})))
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid briefing input" }, { status: 400 })
+    }
+
     const db = createServiceClient()
+    const now = new Date()
+    const content = parsed.data.content || "Daily briefing has been generated."
 
     const briefing = {
-      id: body.id || crypto.randomUUID(),
-      organization_id: body.organization_id,
-      content: body.content || "Daily briefing has been generated.",
-      generated_at: new Date().toISOString(),
-      created_at: new Date().toISOString(),
+      id: crypto.randomUUID(),
+      organization_id: organizationId,
+      date: now.toISOString().split("T")[0],
+      summary: content,
+      content,
+      metrics: [],
+      action_items: [],
+      generated_at: now.toISOString(),
+      created_at: now.toISOString(),
     }
 
     const { data, error } = await db
@@ -33,12 +77,7 @@ export async function POST(request: Request) {
 
     if (error) throw error
     return NextResponse.json(data, { status: 201 })
-  } catch {
-    return NextResponse.json({
-      summary: "Briefing generated.",
-      date: new Date().toISOString().split("T")[0],
-      metrics: [],
-      actionItems: [],
-    }, { status: 201 })
+  } catch (error) {
+    return handleAuthError(error as Error)
   }
 }

--- a/app/api/v1/onboarding/complete/route.ts
+++ b/app/api/v1/onboarding/complete/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getAuthenticatedUser, handleAuthError } from '@/lib/auth/server-auth'
 
 function slugify(name: string): string {
   const base = name.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')
@@ -8,6 +9,7 @@ function slugify(name: string): string {
 
 export async function POST(request: NextRequest) {
   try {
+    const user = await getAuthenticatedUser()
     const data = await request.json()
     const {
       fullName, email, phone,
@@ -20,15 +22,27 @@ export async function POST(request: NextRequest) {
       role?: string; position?: string
     }
 
-    if (!email || !companyName) {
-      return NextResponse.json({ error: 'email and companyName are required' }, { status: 400 })
+    if (!companyName) {
+      return NextResponse.json({ error: 'companyName is required' }, { status: 400 })
+    }
+    if (email && user.email && email.toLowerCase() !== user.email.toLowerCase()) {
+      return NextResponse.json({ error: 'Email does not match the authenticated account' }, { status: 403 })
     }
 
     const db = createServiceClient()
 
-    const { data: profile } = await db.from('profiles').select('id').eq('email', email.toLowerCase()).maybeSingle()
+    // The service-role client bypasses RLS, so profile ownership must come
+    // exclusively from the verified session rather than a caller-supplied email.
+    const { data: profile } = await db
+      .from('profiles')
+      .select('id, organization_id')
+      .eq('id', user.id)
+      .maybeSingle()
     if (!profile) {
-      return NextResponse.json({ error: 'No account found for this email. Please verify your passcode again.' }, { status: 404 })
+      return NextResponse.json({ error: 'No profile found for the authenticated account' }, { status: 404 })
+    }
+    if (profile.organization_id) {
+      return NextResponse.json({ error: 'Onboarding has already been completed' }, { status: 409 })
     }
 
     const { data: org, error: orgError } = await db
@@ -48,22 +62,25 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Failed to create organization' }, { status: 500 })
     }
 
-    const { error: profileError } = await db
+    const { data: updatedProfile, error: profileError } = await db
       .from('profiles')
       .update({
         full_name: fullName || null,
         phone: phone || null,
-        role: role || 'member',
+        role: role === 'owner' || role === 'admin' ? role : 'member',
         organization_id: org.id,
       })
       .eq('id', profile.id)
+      .is('organization_id', null)
+      .select('id')
+      .maybeSingle()
 
-    if (profileError) {
+    if (profileError || !updatedProfile) {
       return NextResponse.json({ error: 'Failed to update profile' }, { status: 500 })
     }
 
     return NextResponse.json({ success: true, organizationId: org.id, position: position ?? null })
-  } catch {
-    return NextResponse.json({ error: 'Failed to complete onboarding' }, { status: 500 })
+  } catch (error) {
+    return handleAuthError(error as Error)
   }
 }

--- a/app/api/v1/operations/whatsapp-webhook/route.ts
+++ b/app/api/v1/operations/whatsapp-webhook/route.ts
@@ -1,5 +1,15 @@
 import { NextResponse } from 'next/server'
+import { createHmac, timingSafeEqual } from 'node:crypto'
 import { verifyWhatsAppWebhook, parseWhatsAppWebhookPayload, ingestWhatsAppMessage } from '@/lib/operational/whatsapp'
+
+function hasValidMetaSignature(rawBody: string, signature: string | null): boolean {
+  const appSecret = process.env.WHATSAPP_APP_SECRET
+  if (!appSecret || !signature?.startsWith('sha256=')) return false
+
+  const supplied = Buffer.from(signature.slice('sha256='.length), 'hex')
+  const expected = createHmac('sha256', appSecret).update(rawBody).digest()
+  return supplied.length === expected.length && timingSafeEqual(supplied, expected)
+}
 
 // Meta's webhook verification handshake: echo back hub.challenge as plain
 // text if hub.verify_token matches WHATSAPP_VERIFY_TOKEN.
@@ -23,6 +33,11 @@ export async function GET(request: Request) {
 // Always acks 200 fast, per Meta's webhook requirements, even on internal
 // failure -- Meta retries aggressively on non-200s.
 export async function POST(request: Request) {
+  const rawBody = await request.text()
+  if (!hasValidMetaSignature(rawBody, request.headers.get('x-hub-signature-256'))) {
+    return NextResponse.json({ error: 'Invalid webhook signature' }, { status: 401 })
+  }
+
   const organizationId = process.env.DEFAULT_OPERATIONS_ORG_ID
   if (!organizationId) {
     console.error('[whatsapp-webhook] DEFAULT_OPERATIONS_ORG_ID is not configured -- dropping message')
@@ -30,7 +45,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const body = await request.json()
+    const body = JSON.parse(rawBody)
     const messages = await parseWhatsAppWebhookPayload(body)
     await Promise.all(messages.map((msg) => ingestWhatsAppMessage(organizationId, msg)))
   } catch (error) {

--- a/app/api/v1/organization/route.ts
+++ b/app/api/v1/organization/route.ts
@@ -3,7 +3,11 @@ import { createServiceClient } from "@/lib/supabase/service"
 import { logAuthEvent, getClientIp } from "@/lib/auth/audit"
 import { NextResponse } from "next/server"
 
-export const PUT = withAuth(async (req, { organizationId, userId }) => {
+export const PUT = withAuth(async (req, { organizationId, userId, role }) => {
+  if (role !== "owner" && role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
   const { name, slug } = await req.json()
 
   if (!name && !slug) {

--- a/app/api/v1/resources/assets/route.ts
+++ b/app/api/v1/resources/assets/route.ts
@@ -1,6 +1,23 @@
 import { NextResponse } from 'next/server'
+import { z } from 'zod'
 import { extractTenantContext } from '@/lib/multitenant/context.server'
-import { createAsset, type AssetNode } from '@/lib/resources/assets'
+import { createAsset } from '@/lib/resources/assets'
+
+const CreateAssetSchema = z.object({
+  name: z.string().trim().min(1).max(255),
+  category: z.string().trim().max(100).nullable().optional().default(null),
+  subcategory: z.string().trim().max(100).nullable().optional().default(null),
+  parent_id: z.string().uuid().nullable().optional().default(null),
+  serial_number: z.string().trim().max(255).nullable().optional().default(null),
+  asset_tag: z.string().trim().max(255).nullable().optional().default(null),
+  status: z.enum(['active', 'maintenance', 'retired', 'idle']).optional().default('active'),
+  location: z.string().trim().max(255).nullable().optional().default(null),
+  purchase_date: z.string().date().nullable().optional().default(null),
+  purchase_value: z.number().nonnegative().nullable().optional().default(null),
+  current_value: z.number().nonnegative().nullable().optional().default(null),
+  warranty_expiry: z.string().date().nullable().optional().default(null),
+  metadata: z.record(z.unknown()).optional().default({}),
+}).strict()
 
 export async function POST(request: Request) {
   const ctx = await extractTenantContext()
@@ -8,12 +25,12 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const body = (await request.json()) as Partial<AssetNode>
-  if (!body.name) {
-    return NextResponse.json({ error: 'name is required' }, { status: 400 })
+  const parsed = CreateAssetSchema.safeParse(await request.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid asset data', details: parsed.error.flatten() }, { status: 400 })
   }
 
-  const asset = await createAsset(ctx.organizationId, body, ctx.userId)
+  const asset = await createAsset(ctx.organizationId, parsed.data, ctx.userId)
   if (!asset) {
     return NextResponse.json({ error: 'Failed to create asset' }, { status: 500 })
   }

--- a/app/api/webhooks/razorpay/route.ts
+++ b/app/api/webhooks/razorpay/route.ts
@@ -1,0 +1,55 @@
+import { handleRazorpayWebhook, verifyRazorpaySignature } from "@/lib/billing/razorpay"
+import { NextResponse } from "next/server"
+import { headers } from "next/headers"
+
+// Razorpay webhook receiver. lib/billing/razorpay.ts's handleRazorpayWebhook
+// (signature-adjacent business logic: idempotency claim + subscription/
+// payment event handling) was fully written but had no route wired up to
+// receive Razorpay's webhook POSTs -- this was the missing piece.
+//
+// Signature verification follows Razorpay's documented webhook contract:
+// the raw request body is HMAC-SHA256'd with the webhook secret (configured
+// in the Razorpay dashboard, not the RAZORPAY_KEY_SECRET used for API auth)
+// and compared against the `X-Razorpay-Signature` header.
+export async function POST(req: Request) {
+  const body = await req.text()
+  const headersList = await headers()
+  const signature = headersList.get("x-razorpay-signature")
+
+  if (!signature) {
+    return NextResponse.json({ error: "No signature" }, { status: 400 })
+  }
+
+  const webhookSecret = process.env.RAZORPAY_WEBHOOK_SECRET
+  if (!webhookSecret) {
+    return NextResponse.json({ error: "Webhook secret is not configured" }, { status: 500 })
+  }
+
+  if (!verifyRazorpaySignature(body, signature, webhookSecret)) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 400 })
+  }
+
+  let payload: Record<string, unknown>
+  try {
+    payload = JSON.parse(body)
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 })
+  }
+
+  // Per lib/billing/razorpay.ts's handleRazorpayWebhook, Razorpay's delivery
+  // id (used for idempotency dedup via claimWebhookEvent) is supplied via
+  // this header.
+  const eventId = headersList.get("x-razorpay-event-id")
+  if (!eventId) {
+    return NextResponse.json({ error: "Missing webhook event ID" }, { status: 400 })
+  }
+
+  try {
+    await handleRazorpayWebhook(payload, eventId)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error"
+    return NextResponse.json({ error: `Webhook handler error: ${message}` }, { status: 500 })
+  }
+
+  return NextResponse.json({ received: true })
+}

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1,5 +1,8 @@
 import { stripe } from "@/lib/stripe"
-import { createClient } from "@/lib/supabase/server"
+import { createServiceClient } from "@/lib/supabase/service"
+import { claimWebhookEvent, completeWebhookEvent, failWebhookEvent } from "@/lib/billing/idempotency"
+import { recordDiscountUse } from "@/lib/billing/discounts"
+import { getPlanIdFromStripePriceId } from "@/lib/products"
 import { NextResponse } from "next/server"
 import { headers } from "next/headers"
 
@@ -26,9 +29,23 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: `Webhook Error: ${message}` }, { status: 400 })
   }
 
-  const supabase = await createClient()
+  // Dedupe against the webhook_events ledger before doing any work -- Stripe
+  // retries deliveries that don't get a fast 2xx, and without this guard a
+  // retried checkout.session.completed would re-run the discount redemption
+  // and subscription writes below a second time.
+  const firstTime = await claimWebhookEvent("stripe", event.id, event.type)
+  if (!firstTime) {
+    return NextResponse.json({ received: true, duplicate: true })
+  }
 
-  switch (event.type) {
+  // Service-role client: this route has no user session to bind cookies to
+  // (Stripe calls it server-to-server), and the subscriptions table's RLS
+  // policy only grants SELECT, not UPDATE -- the trust boundary here is the
+  // verified Stripe signature above, not a user session.
+  const supabase = createServiceClient()
+
+  try {
+    switch (event.type) {
     case "checkout.session.completed": {
       const session = event.data.object
       const organizationId = session.metadata?.organization_id
@@ -45,20 +62,48 @@ export async function POST(req: Request) {
           ? new Date(stripeSub.trial_end * 1000).toISOString()
           : null
 
-        await supabase
+        // Use the real Stripe subscription's period + interval (same fields
+        // the customer.subscription.updated handler below reads) instead of
+        // assuming a 30-day monthly period -- annual/other-interval plans
+        // were getting a period_end 11+ months too early.
+        const periodStart = stripeSub?.current_period_start
+          ? new Date(stripeSub.current_period_start * 1000).toISOString()
+          : new Date().toISOString()
+        const periodEnd = stripeSub?.current_period_end
+          ? new Date(stripeSub.current_period_end * 1000).toISOString()
+          : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString()
+        const billingInterval = stripeSub?.items.data[0]?.price?.recurring?.interval || "month"
+
+        const { error: subscriptionUpdateError } = await supabase
           .from("subscriptions")
           .update({
             stripe_subscription_id: subscriptionId,
             plan_id: planId,
             status: isTrialing ? "trialing" : "active",
             trial_ends_at: trialEnd,
-            current_period_start: new Date().toISOString(),
-            current_period_end: new Date(
-              Date.now() + 30 * 24 * 60 * 60 * 1000
-            ).toISOString(),
-            billing_interval: "month",
+            current_period_start: periodStart,
+            current_period_end: periodEnd,
+            billing_interval: billingInterval,
           })
           .eq("organization_id", organizationId)
+        if (subscriptionUpdateError) throw subscriptionUpdateError
+
+        // Claim the discount redemption now that payment is confirmed --
+        // NOT at checkout creation, so an abandoned checkout never burns a
+        // use (see lib/billing/discounts.ts).
+        const discountCode = session.metadata?.discount_code
+        if (discountCode) {
+          const { claimed, discount } = await recordDiscountUse(discountCode, organizationId, session.id)
+          if (claimed && discount) {
+            const { error: billingEventError } = await supabase.from("billing_events").insert({
+              organization_id: organizationId,
+              event_type: "discount_applied",
+              provider: "stripe",
+              metadata: { code: discount.code, value: discount.value, plan_id: planId },
+            })
+            if (billingEventError) throw billingEventError
+          }
+        }
       }
       break
     }
@@ -68,7 +113,14 @@ export async function POST(req: Request) {
       const organizationId = subscription.metadata?.organization_id
 
       if (organizationId) {
-        await supabase
+        // A billing-portal-driven plan change lands here with no
+        // checkout.session.completed event at all -- derive plan_id from the
+        // subscription's current price so plan_id doesn't silently desync
+        // from what Stripe (and the customer) actually has.
+        const priceId = subscription.items.data[0]?.price?.id
+        const planId = getPlanIdFromStripePriceId(priceId)
+
+        const { error: subscriptionUpdateError } = await supabase
           .from("subscriptions")
           .update({
             status: subscription.status,
@@ -79,8 +131,10 @@ export async function POST(req: Request) {
             current_period_end: new Date(
               subscription.current_period_end * 1000
             ).toISOString(),
+            ...(planId ? { plan_id: planId } : {}),
           })
           .eq("organization_id", organizationId)
+        if (subscriptionUpdateError) throw subscriptionUpdateError
       }
       break
     }
@@ -90,13 +144,14 @@ export async function POST(req: Request) {
       const organizationId = subscription.metadata?.organization_id
 
       if (organizationId) {
-        await supabase
+        const { error: subscriptionUpdateError } = await supabase
           .from("subscriptions")
           .update({
             status: "canceled",
             stripe_subscription_id: null,
           })
           .eq("organization_id", organizationId)
+        if (subscriptionUpdateError) throw subscriptionUpdateError
       }
       break
     }
@@ -105,20 +160,27 @@ export async function POST(req: Request) {
       const invoice = event.data.object
       const customerId = invoice.customer as string
 
-      const { data } = await supabase
+      const { data, error: subscriptionReadError } = await supabase
         .from("subscriptions")
         .select("organization_id")
         .eq("stripe_customer_id", customerId)
         .single()
+      if (subscriptionReadError) throw subscriptionReadError
 
       if (data?.organization_id) {
-        await supabase
+        const { error: subscriptionUpdateError } = await supabase
           .from("subscriptions")
           .update({ status: "past_due" })
           .eq("organization_id", data.organization_id)
+        if (subscriptionUpdateError) throw subscriptionUpdateError
       }
       break
     }
+    }
+    await completeWebhookEvent("stripe", event.id)
+  } catch (error) {
+    await failWebhookEvent("stripe", event.id, error)
+    throw error
   }
 
   return NextResponse.json({ received: true })

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -5,6 +5,29 @@ import { isPlatformOwnerEmail } from "@/lib/platform/owner"
 import type { EmailOtpType, User } from "@supabase/supabase-js"
 import { NextResponse } from "next/server"
 
+export function sanitizeCallbackPath(path: string | null): string {
+  if (!path) return "/"
+  const normalized = path.replace(/\\/g, "/")
+  if (!normalized.startsWith("/") || normalized.startsWith("//")) return "/"
+  return normalized
+}
+
+export function getCallbackOrigin(request: Request): string | null {
+  const configuredOrigin = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL
+  if (configuredOrigin) {
+    try {
+      return new URL(configuredOrigin).origin
+    } catch {
+      return null
+    }
+  }
+
+  // Request origins are acceptable for local development only. In production,
+  // proxy forwarding headers are caller-controlled unless the complete proxy
+  // chain is configured perfectly, so a missing canonical URL must fail closed.
+  return process.env.NODE_ENV === "development" ? new URL(request.url).origin : null
+}
+
 async function ensureUserProfile(
   user: User,
   db: ReturnType<typeof createServiceClient>,
@@ -69,19 +92,20 @@ async function ensureUserProfile(
 }
 
 export async function GET(request: Request) {
-  const { searchParams, origin } = new URL(request.url)
+  const { searchParams } = new URL(request.url)
   const code = searchParams.get("code")
   const tokenHash = searchParams.get("token_hash")
   const type = searchParams.get("type") as EmailOtpType | null
-  const next = searchParams.get("next") ?? "/"
+  const next = sanitizeCallbackPath(searchParams.get("next"))
+  const callbackOrigin = getCallbackOrigin(request)
+
+  if (!callbackOrigin) {
+    console.error("[auth] Missing or invalid canonical site URL for callback")
+    return NextResponse.json({ error: "Authentication callback is unavailable" }, { status: 503 })
+  }
 
   const buildRedirect = (path: string) => {
-    const forwardedHost = request.headers.get("x-forwarded-host")
-    const isLocalEnv = process.env.NODE_ENV === "development"
-    if (!isLocalEnv && forwardedHost) {
-      return NextResponse.redirect(`https://${forwardedHost}${path}`)
-    }
-    return NextResponse.redirect(`${origin}${path}`)
+    return NextResponse.redirect(new URL(sanitizeCallbackPath(path), callbackOrigin))
   }
 
   const supabase = await createClient()

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -132,6 +132,13 @@ function LoginForm() {
                  </span>
               </Button>
 
+              {passkeyError && (
+                <div className="flex items-center gap-2 text-sm text-destructive" role="alert">
+                  <AlertCircle className="h-4 w-4 shrink-0" />
+                  {passkeyError}
+                </div>
+              )}
+
               <div className="relative">
                 <div className="absolute inset-0 flex items-center">
                   <span className="w-full border-t border-border/50" />

--- a/lib/auth/passwordless/service.ts
+++ b/lib/auth/passwordless/service.ts
@@ -1,7 +1,7 @@
-import { randomBytes, createHash } from "node:crypto"
+import { createHash } from "node:crypto"
 import { createServiceClient } from "@/lib/supabase/service"
 import { DEFAULT_PASSWORDLESS_CONFIG, PasswordlessError, PasswordlessErrorCode } from "./types"
-import type { MagicLinkOptions, MagicLinkToken, PasswordlessConfig } from "./types"
+import type { MagicLinkOptions, PasswordlessConfig } from "./types"
 import { logger } from "@/lib/logging"
 
 function generatePasscode(): string {
@@ -123,7 +123,18 @@ export async function verifyMagicLink(
   const expiresAt = new Date(record.expires_at as string)
   if (expiresAt < new Date()) return null
 
-  await db.from("magic_link_tokens").update({ used: true, used_at: new Date().toISOString() }).eq("id", record.id)
+  // Claim the token atomically. The `used = false` predicate is rechecked by
+  // Postgres when concurrent updates contend for the same row, so only one
+  // request receives a row and proceeds to session creation.
+  const { data: consumed, error } = await db
+    .from("magic_link_tokens")
+    .update({ used: true, used_at: new Date().toISOString() })
+    .eq("id", record.id)
+    .eq("used", false)
+    .select("user_id")
+    .maybeSingle()
 
-  return record.user_id as string
+  if (error || !consumed || consumed.user_id !== record.user_id) return null
+
+  return consumed.user_id as string
 }

--- a/lib/auth/webauthn/service.ts
+++ b/lib/auth/webauthn/service.ts
@@ -32,11 +32,16 @@ export async function createWebAuthnRegistrationOptions(userId: string, email: s
   })
 
   const db = createServiceClient()
-  await db.from("webauthn_challenges").insert({
+  const { error } = await db.from("webauthn_challenges").insert({
     email: email.toLowerCase(),
     challenge: options.challenge,
     expires_at: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
   })
+
+  if (error) {
+    logger.logError("[webauthn] Failed to persist registration challenge", { error })
+    throw new Error("Failed to persist registration challenge")
+  }
 
   return options
 }
@@ -88,16 +93,6 @@ export async function verifyWebAuthnRegistrationResponse(
   }
 }
 
-interface WebAuthnCredential {
-  id: string
-  publicKey: string
-  counter: number
-  deviceType: string
-  transports?: string[]
-  createdAt: string
-  lastUsedAt?: string
-}
-
 interface RegisterWebAuthnOptions {
   userId: string
   credential: {
@@ -119,7 +114,7 @@ export async function registerWebAuthnCredential(options: RegisterWebAuthnOption
   const db = createServiceClient()
 
   try {
-    await db.from("user_devices").insert({
+    const { error } = await db.from("user_devices").insert({
       user_id: options.userId,
       credential_id: options.credential.id,
       public_key: options.credential.publicKey,
@@ -129,6 +124,11 @@ export async function registerWebAuthnCredential(options: RegisterWebAuthnOption
       device_name: options.deviceName || `Device ${new Date().toLocaleString()}`,
       last_used_at: new Date().toISOString(),
     })
+
+    if (error) {
+      logger.logError("[webauthn] Failed to save credential", { error })
+      return { success: false, error: "Failed to register device" }
+    }
     return { success: true }
   } catch (error) {
     logger.logError("[webauthn] Registration failed:", { error })

--- a/lib/billing/idempotency.ts
+++ b/lib/billing/idempotency.ts
@@ -1,13 +1,20 @@
 import { createServiceClient } from "@/lib/supabase/service"
 
+const WEBHOOK_LEASE_MS = 5 * 60 * 1000
+
+type WebhookEventState = {
+  status: "processing" | "completed" | "failed"
+  claimed_at: string | null
+  attempts: number | null
+}
+
 /**
  * Webhook idempotency guard (blocker D).
  *
  * Claims an inbound webhook delivery against the `webhook_events` ledger using
  * its provider-supplied event id. Returns:
  *   - `true`  → first time we have seen this event; the caller SHOULD process it.
- *   - `false` → already recorded (duplicate retry / duplicate endpoint); the
- *               caller SHOULD skip processing so no action runs twice.
+ *   - `false` → already completed; the caller SHOULD skip it.
  *
  * The ledger has a unique (provider, event_id) constraint, so the claim is
  * atomic across concurrent deliveries — the second insert loses with a 23505
@@ -27,17 +34,90 @@ export async function claimWebhookEvent(
   }
 
   const db = createServiceClient()
+  const claimedAt = new Date().toISOString()
   const { error } = await db
     .from("webhook_events")
-    .insert({ provider, event_id: eventId, event_type: eventType ?? null })
+    .insert({
+      provider,
+      event_id: eventId,
+      event_type: eventType ?? null,
+      status: "processing",
+      claimed_at: claimedAt,
+      attempts: 1,
+    })
 
   if (!error) return true
 
-  // 23505 = unique_violation → this delivery was already claimed.
-  if ((error as { code?: string }).code === "23505") return false
+  if ((error as { code?: string }).code === "23505") {
+    const { data: existing, error: readError } = await db
+      .from("webhook_events")
+      .select("status, claimed_at, attempts")
+      .eq("provider", provider)
+      .eq("event_id", eventId)
+      .single()
+
+    if (readError || !existing) {
+      throw new Error(`Unable to inspect ${provider} webhook event claim`)
+    }
+
+    const state = existing as WebhookEventState
+    if (state.status === "completed") return false
+
+    const leaseExpired = state.status === "processing" &&
+      (!state.claimed_at || Date.now() - new Date(state.claimed_at).getTime() >= WEBHOOK_LEASE_MS)
+    if (state.status === "processing" && !leaseExpired) {
+      throw new Error(`${provider} webhook event is already processing`)
+    }
+
+    let retry = db
+      .from("webhook_events")
+      .update({
+        status: "processing",
+        claimed_at: claimedAt,
+        completed_at: null,
+        last_error: null,
+        attempts: (state.attempts ?? 1) + 1,
+      })
+      .eq("provider", provider)
+      .eq("event_id", eventId)
+      .eq("status", state.status)
+
+    if (state.claimed_at) retry = retry.eq("claimed_at", state.claimed_at)
+    const { data: reclaimed, error: retryError } = await retry.select("id").maybeSingle()
+    if (retryError) throw new Error(`Unable to reclaim ${provider} webhook event`)
+    if (!reclaimed) throw new Error(`${provider} webhook event is already processing`)
+    return true
+  }
 
   // An unexpected ledger failure means idempotency cannot be guaranteed.
   // Throw so the webhook returns a non-2xx response and the provider retries.
   console.error("[v0] claimWebhookEvent ledger error:", error.message)
   throw new Error(`Unable to claim ${provider} webhook event`)
+}
+
+export async function completeWebhookEvent(provider: string, eventId: string): Promise<void> {
+  const db = createServiceClient()
+  const { data, error } = await db
+    .from("webhook_events")
+    .update({ status: "completed", completed_at: new Date().toISOString(), last_error: null })
+    .eq("provider", provider)
+    .eq("event_id", eventId)
+    .eq("status", "processing")
+    .select("id")
+    .maybeSingle()
+
+  if (error || !data) throw new Error(`Unable to complete ${provider} webhook event`)
+}
+
+export async function failWebhookEvent(provider: string, eventId: string, error: unknown): Promise<void> {
+  const db = createServiceClient()
+  const message = error instanceof Error ? error.message : String(error)
+  const { error: updateError } = await db
+    .from("webhook_events")
+    .update({ status: "failed", last_error: message.slice(0, 1000) })
+    .eq("provider", provider)
+    .eq("event_id", eventId)
+    .eq("status", "processing")
+
+  if (updateError) console.error("[v0] Failed to release webhook event claim:", updateError.message)
 }

--- a/lib/billing/idempotency.ts
+++ b/lib/billing/idempotency.ts
@@ -13,16 +13,18 @@ import { createServiceClient } from "@/lib/supabase/service"
  * atomic across concurrent deliveries — the second insert loses with a 23505
  * unique violation and is treated as a duplicate.
  *
- * If no event id is available we cannot dedupe, so we fail OPEN (process) to
- * preserve at-least-once delivery — better to risk a rare duplicate than to
- * silently drop a billing event.
+ * Missing delivery IDs and ledger failures fail closed. Payment providers
+ * retry non-2xx deliveries, while processing without an atomic claim can
+ * duplicate subscription mutations, event rows, or discount redemption.
  */
 export async function claimWebhookEvent(
   provider: string,
   eventId: string | null | undefined,
   eventType?: string,
 ): Promise<boolean> {
-  if (!eventId) return true
+  if (!eventId) {
+    throw new Error(`Missing ${provider} webhook event ID`)
+  }
 
   const db = createServiceClient()
   const { error } = await db
@@ -34,7 +36,8 @@ export async function claimWebhookEvent(
   // 23505 = unique_violation → this delivery was already claimed.
   if ((error as { code?: string }).code === "23505") return false
 
-  // Unexpected ledger error: log and fail open so we don't drop the event.
+  // An unexpected ledger failure means idempotency cannot be guaranteed.
+  // Throw so the webhook returns a non-2xx response and the provider retries.
   console.error("[v0] claimWebhookEvent ledger error:", error.message)
-  return true
+  throw new Error(`Unable to claim ${provider} webhook event`)
 }

--- a/lib/billing/razorpay.ts
+++ b/lib/billing/razorpay.ts
@@ -2,7 +2,7 @@ import axios from "axios"
 import crypto from "crypto"
 import { createServiceClient } from "@/lib/supabase/service"
 import { logAuthEvent } from "@/lib/auth/audit"
-import { claimWebhookEvent } from "./idempotency"
+import { claimWebhookEvent, completeWebhookEvent, failWebhookEvent } from "./idempotency"
 import type { BillingPlan } from "./types"
 import { logger } from "@/lib/logging"
 
@@ -209,7 +209,7 @@ export async function handleRazorpayWebhook(
           const orgId = metadata?.organization_id
 
           if (orgId) {
-            await supabase
+            const { error: subscriptionError } = await supabase
               .from("subscriptions")
               .update({
                 razorpay_subscription_id: subscription.id,
@@ -217,8 +217,9 @@ export async function handleRazorpayWebhook(
                 status: "active",
               })
               .eq("organization_id", orgId)
+            if (subscriptionError) throw subscriptionError
 
-            await supabase.from("billing_events").insert({
+            const { error: eventError } = await supabase.from("billing_events").insert({
               organization_id: orgId,
               event_type: "subscription.created",
               provider: "razorpay",
@@ -226,6 +227,7 @@ export async function handleRazorpayWebhook(
               status: "completed",
               metadata: { plan: metadata?.plan },
             })
+            if (eventError) throw eventError
           }
         }
         break
@@ -237,7 +239,7 @@ export async function handleRazorpayWebhook(
           const orgId = paymentMeta?.organization_id
 
           if (orgId && payment.amount) {
-            await supabase.from("billing_events").insert({
+            const { error: eventError } = await supabase.from("billing_events").insert({
               organization_id: orgId,
               event_type: "payment.completed",
               provider: "razorpay",
@@ -245,6 +247,7 @@ export async function handleRazorpayWebhook(
               amount: (payment.amount as number) / 100,
               status: "completed",
             })
+            if (eventError) throw eventError
           }
         }
         break
@@ -256,7 +259,7 @@ export async function handleRazorpayWebhook(
           const orgId = paymentMeta?.organization_id
 
           if (orgId) {
-            await supabase.from("billing_events").insert({
+            const { error: eventError } = await supabase.from("billing_events").insert({
               organization_id: orgId,
               event_type: "payment.failed",
               provider: "razorpay",
@@ -264,6 +267,7 @@ export async function handleRazorpayWebhook(
               status: "failed",
               error_message: payment.error_description as string,
             })
+            if (eventError) throw eventError
           }
         }
         break
@@ -275,27 +279,32 @@ export async function handleRazorpayWebhook(
           const orgId = metadata?.organization_id
 
           if (orgId) {
-            await supabase
+            const { error: subscriptionError } = await supabase
               .from("subscriptions")
               .update({
                 status: "cancelled",
                 cancelled_at: new Date().toISOString(),
               })
               .eq("organization_id", orgId)
+            if (subscriptionError) throw subscriptionError
 
-            await supabase.from("billing_events").insert({
+            const { error: eventError } = await supabase.from("billing_events").insert({
               organization_id: orgId,
               event_type: "subscription.cancelled",
               provider: "razorpay",
               external_id: subscription.id as string,
               status: "completed",
             })
+            if (eventError) throw eventError
           }
         }
         break
       }
     }
+    if (!eventId) throw new Error("Missing Razorpay webhook event ID")
+    await completeWebhookEvent("razorpay", eventId)
   } catch (err) {
+    if (eventId) await failWebhookEvent("razorpay", eventId, err)
     console.error("[v0] Failed to handle Razorpay webhook:", err)
     throw err
   }

--- a/lib/billing/stripe.ts
+++ b/lib/billing/stripe.ts
@@ -1,6 +1,6 @@
 import { createServiceClient } from "@/lib/supabase/service"
 import { logAuthEvent } from "@/lib/auth/audit"
-import { claimWebhookEvent } from "./idempotency"
+import { claimWebhookEvent, completeWebhookEvent, failWebhookEvent } from "./idempotency"
 import type { BillingPlan } from "./types"
 import type Stripe from "stripe"
 import { logger } from "@/lib/logging"
@@ -238,7 +238,7 @@ export async function handleStripeWebhook(event: Stripe.Event): Promise<void> {
           const isTrialing = subscription.status === "trialing"
           const status = isTrialing ? "trialing" : "active"
 
-          await supabase
+          const { error: subscriptionError } = await supabase
             .from("subscriptions")
             .update({
               stripe_subscription_id: subscription.id,
@@ -248,8 +248,9 @@ export async function handleStripeWebhook(event: Stripe.Event): Promise<void> {
                 : null,
             })
             .eq("organization_id", orgId)
+          if (subscriptionError) throw subscriptionError
 
-          await supabase.from("billing_events").insert({
+          const { error: eventError } = await supabase.from("billing_events").insert({
             organization_id: orgId,
             event_type: isTrialing ? "subscription.trial_started" : "subscription.created",
             provider: "stripe",
@@ -257,6 +258,7 @@ export async function handleStripeWebhook(event: Stripe.Event): Promise<void> {
             status: "completed",
             metadata: { plan: (subscription.metadata as Record<string, string>)?.plan },
           })
+          if (eventError) throw eventError
         }
         break
       }
@@ -274,7 +276,7 @@ export async function handleStripeWebhook(event: Stripe.Event): Promise<void> {
           else if (isPastDue) status = "past_due"
           else if (subscription.cancel_at_period_end) status = "cancelled"
 
-          await supabase
+          const { error: subscriptionError } = await supabase
             .from("subscriptions")
             .update({
               status,
@@ -284,8 +286,9 @@ export async function handleStripeWebhook(event: Stripe.Event): Promise<void> {
               cancel_at_period_end: subscription.cancel_at_period_end,
             })
             .eq("organization_id", orgId)
+          if (subscriptionError) throw subscriptionError
 
-          await supabase.from("billing_events").insert({
+          const { error: eventError } = await supabase.from("billing_events").insert({
             organization_id: orgId,
             event_type: "subscription.updated",
             provider: "stripe",
@@ -293,6 +296,7 @@ export async function handleStripeWebhook(event: Stripe.Event): Promise<void> {
             status: "completed",
             metadata: { plan: (subscription.metadata as Record<string, string>)?.plan, status },
           })
+          if (eventError) throw eventError
         }
         break
       }
@@ -310,8 +314,9 @@ export async function handleStripeWebhook(event: Stripe.Event): Promise<void> {
               .select("id")
               .eq("stripe_subscription_id", subscription.id)
               .single()
+            if (subRecord.error) throw subRecord.error
 
-            await supabase.from("billing_events").insert({
+            const { error: eventError } = await supabase.from("billing_events").insert({
               organization_id: orgId,
               subscription_id: subRecord.data?.id,
               event_type: "payment.completed",
@@ -320,6 +325,7 @@ export async function handleStripeWebhook(event: Stripe.Event): Promise<void> {
               amount: invoice.amount_paid / 100,
               status: "completed",
             })
+            if (eventError) throw eventError
           }
         }
         break
@@ -333,7 +339,7 @@ export async function handleStripeWebhook(event: Stripe.Event): Promise<void> {
           const orgId = (subscription.metadata as Record<string, string>)?.organization_id
 
           if (orgId) {
-            await supabase.from("billing_events").insert({
+            const { error: eventError } = await supabase.from("billing_events").insert({
               organization_id: orgId,
               event_type: "payment.failed",
               provider: "stripe",
@@ -341,6 +347,7 @@ export async function handleStripeWebhook(event: Stripe.Event): Promise<void> {
               status: "failed",
               error_message: invoice.last_finalization_error?.code || "Payment failed",
             })
+            if (eventError) throw eventError
           }
         }
         break
@@ -351,23 +358,27 @@ export async function handleStripeWebhook(event: Stripe.Event): Promise<void> {
         const orgId = (subscription.metadata as Record<string, string>)?.organization_id
 
         if (orgId) {
-          await supabase
+          const { error: subscriptionError } = await supabase
             .from("subscriptions")
             .update({ status: "cancelled", cancelled_at: new Date().toISOString() })
             .eq("organization_id", orgId)
+          if (subscriptionError) throw subscriptionError
 
-          await supabase.from("billing_events").insert({
+          const { error: eventError } = await supabase.from("billing_events").insert({
             organization_id: orgId,
             event_type: "subscription.cancelled",
             provider: "stripe",
             external_id: subscription.id,
             status: "completed",
           })
+          if (eventError) throw eventError
         }
         break
       }
     }
+    await completeWebhookEvent("stripe", event.id)
   } catch (err) {
+    await failWebhookEvent("stripe", event.id, err)
     console.error("[v0] Failed to handle Stripe webhook:", err)
     throw err
   }

--- a/lib/billing/subscription-lifecycle.ts
+++ b/lib/billing/subscription-lifecycle.ts
@@ -170,9 +170,11 @@ export async function isWithinRefundWindow(organizationId: string): Promise<bool
   if (sub.billing_interval === "year") return false
 
   const startDate = new Date(sub.current_period_start)
+  if (Number.isNaN(startDate.getTime())) return false
+
   const daysSinceStart = Math.floor((Date.now() - startDate.getTime()) / (1000 * 60 * 60 * 24))
 
-  return daysSinceStart <= REFUND_WINDOW_DAYS
+  return daysSinceStart >= 0 && daysSinceStart <= REFUND_WINDOW_DAYS
 }
 
 export async function processRefund(

--- a/lib/company/registry-apis.ts
+++ b/lib/company/registry-apis.ts
@@ -8,6 +8,7 @@ export interface RegistryConfig {
 
 export interface RegistryLookupResult {
   found: boolean
+  simulated?: boolean
   companyName?: string
   registrationNumber?: string
   address?: string
@@ -48,6 +49,7 @@ export async function lookupRegistry(
 ): Promise<RegistryLookupResult> {
   const config = getRegistryConfig(country)
   if (!config || config.provider === "simulated") {
+    if (process.env.NODE_ENV === "production") return { found: false }
     return simulatedLookup(registrationNumber, country)
   }
 
@@ -59,6 +61,7 @@ export async function lookupRegistry(
     case "acra":
       return acraLookup(config, registrationNumber)
     default:
+      if (process.env.NODE_ENV === "production") return { found: false }
       return simulatedLookup(registrationNumber, country)
   }
 }
@@ -99,6 +102,9 @@ async function companiesHouseLookup(
   config: RegistryConfig,
   companyNumber: string
 ): Promise<RegistryLookupResult> {
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("Simulated registry lookups are disabled in production")
+  }
   try {
     const response = await fetch(
       `${config.apiUrl}/company/${companyNumber}`,
@@ -158,6 +164,7 @@ async function simulatedLookup(
   if (!found) return { found: false }
   return {
     found: true,
+    simulated: true,
     companyName: `Verified Company ${registrationNumber.slice(0, 6)}`,
     registrationNumber,
     address: "123 Verified Street, Business District",

--- a/lib/company/registry-verification.ts
+++ b/lib/company/registry-verification.ts
@@ -3,6 +3,7 @@
 import { createServiceClient } from "@/lib/supabase/service"
 import { logger } from "@/lib/logging"
 import { lookupRegistry } from "@/lib/company/registry-apis"
+import { getAuthenticatedUser } from "@/lib/auth/server-auth"
 
 interface CompanyVerificationResult {
   verified: boolean
@@ -28,6 +29,7 @@ interface RegistryVerificationOptions {
 export async function verifyCompanyAgainstRegistry(
   options: RegistryVerificationOptions
 ): Promise<CompanyVerificationResult> {
+  await getAuthenticatedUser()
   const { registrationNumber, country, companyName, website } = options
 
   // Check if registration number format is valid for the country
@@ -50,12 +52,18 @@ export async function verifyCompanyAgainstRegistry(
       registrationNumber: registryResult.registrationNumber,
       address: registryResult.address,
       status: registryResult.status === "dissolved" ? "inactive" : registryResult.status,
-      verificationMethod: "registry_api"
+      verificationMethod: registryResult.simulated ? undefined : "registry_api",
+      requiresManualReview: registryResult.simulated ? true : undefined,
+      manualReviewNotes: registryResult.simulated
+        ? "SIMULATED DEVELOPMENT RESULT — not a registry verification"
+        : undefined,
     }
   }
 
-  // Fall back to simulated lookup if real API not found
-  const registryData = await simulateRegistryLookup(registrationNumber, country)
+  // Demo data is allowed only outside production and is clearly marked.
+  const registryData = process.env.NODE_ENV === "production"
+    ? { verified: false }
+    : await simulateRegistryLookup(registrationNumber, country)
 
   if (registryData.verified) {
     return {
@@ -64,7 +72,8 @@ export async function verifyCompanyAgainstRegistry(
       registrationNumber: registryData.registrationNumber,
       address: registryData.address,
       status: registryData.status,
-      verificationMethod: "registry_api"
+      requiresManualReview: true,
+      manualReviewNotes: "SIMULATED DEVELOPMENT RESULT — not a registry verification",
     }
   }
 
@@ -219,20 +228,21 @@ function getCityForCountry(country: string): string {
  * Request manual review for company verification
  */
 export async function requestManualReview(
-  userId: string,
+  _userId: string,
   companyData: RegistryVerificationOptions & {
     userProvidedName: string
     userProvidedWebsite?: string
     userProvidedAddress?: string
   }
 ): Promise<{ success: boolean; reviewId?: string }> {
+  const user = await getAuthenticatedUser()
   const db = createServiceClient()
 
   try {
     const { data: review, error } = await db
       .from("company_verification_reviews")
       .insert({
-        user_id: userId,
+        user_id: user.id,
         company_name: companyData.userProvidedName,
         registration_number: companyData.registrationNumber,
         country: companyData.country,

--- a/lib/compliance/esignatures.ts
+++ b/lib/compliance/esignatures.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "crypto"
+import { createHash } from "crypto"
 import { createServiceClient } from "@/lib/supabase/service"
 import { publish } from "@/lib/events/bus"
 
@@ -40,7 +40,6 @@ export interface SignedDocument {
 export async function createSignatureRequest(
   organizationId: string,
   documentId: string,
-  documentName: string,
   requesterId: string,
   signerEmail: string,
   signerName: string | null = null,
@@ -50,10 +49,21 @@ export async function createSignatureRequest(
 ): Promise<SignatureRequest | null> {
   const db = createServiceClient()
 
+  // The service role bypasses RLS. Resolve the document inside the caller's
+  // tenant and derive its name server-side so a foreign document UUID cannot
+  // be attached to a request in the attacker's organization.
+  const { data: document, error: documentError } = await db
+    .from("documents")
+    .select("id, name")
+    .eq("id", documentId)
+    .eq("organization_id", organizationId)
+    .maybeSingle()
+  if (documentError || !document) return null
+
   const { data, error } = await db.from("esignature_requests").insert({
     organization_id: organizationId,
     document_id: documentId,
-    document_name: documentName,
+    document_name: document.name,
     requester_id: requesterId,
     signer_email: signerEmail,
     signer_name: signerName,
@@ -122,13 +132,18 @@ export async function signDocument(
     signature_hash: signatureHash,
     signed_at: new Date().toISOString(),
     signed_ip: ipAddress,
-  }).eq("id", requestId)
+  })
+    .eq("id", requestId)
+    .eq("organization_id", organizationId)
+    .eq("signer_email", signerEmail)
 
   await db.from("documents").update({
     signature_status: "signed",
     signed_at: new Date().toISOString(),
     signed_by: signerEmail,
-  }).eq("id", req.document_id)
+  })
+    .eq("id", req.document_id)
+    .eq("organization_id", organizationId)
 
   await publish({
     type: "compliance.document_signed",
@@ -209,6 +224,7 @@ export async function rejectSignatureRequest(
     .from("esignature_requests")
     .update({ status: "rejected", message: reason ?? req.message })
     .eq("id", requestId)
+    .eq("organization_id", organizationId)
     .select("*")
     .single()
 

--- a/lib/identity/kyc-providers.ts
+++ b/lib/identity/kyc-providers.ts
@@ -66,6 +66,9 @@ export async function createDocumentCheck(
     case "jumio":
       return jumioDocumentCheck(config, options)
     default:
+      if (process.env.NODE_ENV === "production") {
+        throw new Error(`KYC document checks are not implemented for ${config.name}`)
+      }
       return simulatedCheck("document", options)
   }
 }
@@ -80,6 +83,9 @@ export async function createFaceCheck(
     case "jumio":
       return jumioFaceCheck(config, options)
     default:
+      if (process.env.NODE_ENV === "production") {
+        throw new Error(`KYC face checks are not implemented for ${config.name}`)
+      }
       return simulatedCheck("face", options)
   }
 }
@@ -132,13 +138,14 @@ async function onfidoFaceCheck(
       file: options.selfieImage,
     }),
   })
+  if (!response.ok) throw new Error(`Onfido face check failed (${response.status})`)
   const data = await response.json()
   return {
     checkId: data.id,
     provider: "onfido",
     status: "complete",
-    result: "clear",
-    breakdown: {},
+    result: data.result === "clear" ? "clear" : "consider",
+    breakdown: data.breakdown || {},
     score: data.score || 0,
     completedAt: new Date().toISOString(),
     rawResponse: data,
@@ -147,7 +154,7 @@ async function onfidoFaceCheck(
 
 async function jumioDocumentCheck(
   config: KycProviderConfig,
-  options: DocumentCheckOptions
+  _options: DocumentCheckOptions
 ): Promise<KycCheckResult> {
   const response = await fetch(`${config.apiUrl}/api/v1/accounts/${config.apiKey}/scan`, {
     method: "POST",
@@ -178,25 +185,19 @@ async function jumioDocumentCheck(
 }
 
 async function jumioFaceCheck(
-  config: KycProviderConfig,
-  options: FaceCheckOptions
+  _config: KycProviderConfig,
+  _options: FaceCheckOptions
 ): Promise<KycCheckResult> {
-  return {
-    checkId: `face-${Date.now()}`,
-    provider: "jumio",
-    status: "complete",
-    result: "clear",
-    breakdown: { face_match: true, liveness: options.liveness || false },
-    score: 0.95,
-    completedAt: new Date().toISOString(),
-    rawResponse: {},
-  }
+  throw new Error("Jumio face verification is not implemented")
 }
 
 async function simulatedCheck(
   type: "document" | "face",
   _options: DocumentCheckOptions | FaceCheckOptions
 ): Promise<KycCheckResult> {
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("Simulated KYC checks are disabled in production")
+  }
   await new Promise((r) => setTimeout(r, 1000))
   const confidence = 0.7 + Math.random() * 0.25
   return {

--- a/lib/identity/kyc-verification.ts
+++ b/lib/identity/kyc-verification.ts
@@ -2,6 +2,7 @@
 
 import { createServiceClient } from "@/lib/supabase/service"
 import { logger } from "@/lib/logging"
+import { getAuthenticatedUser } from "@/lib/auth/server-auth"
 import {
   getActiveKycProvider,
   getKycProviderConfig,
@@ -29,6 +30,7 @@ interface KYCVerificationResult {
   verificationMethod?: "automated" | "manual"
   requiresManualReview?: boolean
   manualReviewNotes?: string
+  simulated?: boolean
 }
 
 interface KYCVerificationOptions {
@@ -49,7 +51,8 @@ interface KYCVerificationOptions {
 export async function verifyIdentityWithKYC(
   options: KYCVerificationOptions
 ): Promise<KYCVerificationResult> {
-  const { userId, selfieImage, idType, idNumber, idFrontImage, fullName } = options
+  const user = await getAuthenticatedUser()
+  const { selfieImage, idType } = options
 
   // Validate required fields
   if (!selfieImage || !idType) {
@@ -67,14 +70,25 @@ export async function verifyIdentityWithKYC(
     const config = getKycProviderConfig(providerName)
     if (config) {
       const result = await performProviderKycCheck(config, options)
-      await storeKYCVerificationResult(userId, result)
+      await storeKYCVerificationResult(user.id, result)
       return result
     }
   }
 
-  // Fall back to simulated verification
+  if (process.env.NODE_ENV === "production") {
+    const result: KYCVerificationResult = {
+      verified: false,
+      confidenceScore: 0,
+      requiresManualReview: true,
+      manualReviewNotes: "KYC provider is not configured",
+    }
+    await storeKYCVerificationResult(user.id, result)
+    return result
+  }
+
+  // Explicit development-only demo verification.
   const result = await simulateKYCVerification(options)
-  await storeKYCVerificationResult(userId, result)
+  await storeKYCVerificationResult(user.id, result)
   return result
 }
 
@@ -178,7 +192,8 @@ async function simulateKYCVerification(
     nameOnId: options.fullName,
     verificationMethod: requiresManualReview ? undefined : "automated",
     requiresManualReview,
-    manualReviewNotes: requiresManualReview ? "Confidence score below threshold" : undefined
+    manualReviewNotes: "SIMULATED DEVELOPMENT RESULT — not a KYC decision",
+    simulated: true,
   }
 }
 
@@ -238,17 +253,18 @@ async function storeKYCVerificationResult(
  * Request manual review for KYC verification
  */
 export async function requestKYCManualReview(
-  userId: string,
+  _userId: string,
   options: KYCVerificationOptions,
   notes?: string
 ): Promise<{ success: boolean; reviewId?: string }> {
+  const user = await getAuthenticatedUser()
   const db = createServiceClient()
 
   try {
     const { data: review, error } = await db
       .from("kyc_verification_reviews")
       .insert({
-        user_id: userId,
+        user_id: user.id,
         selfie_image: options.selfieImage,
         id_type: options.idType,
         id_number: options.idNumber,
@@ -278,6 +294,8 @@ export async function requestKYCManualReview(
  * Get KYC verification status for a user
  */
 export async function getKYCVerificationStatus(userId: string): Promise<KYCVerificationResult | null> {
+  const user = await getAuthenticatedUser()
+  if (user.id !== userId) throw new Error("Forbidden")
   const db = createServiceClient()
 
   try {

--- a/lib/multitenant/types.ts
+++ b/lib/multitenant/types.ts
@@ -3,7 +3,7 @@ export interface TenantContextMiddleware {
   organizationId: string
   userId: string
   email: string
-  role: "admin" | "member" | "viewer"
+  role: "owner" | "admin" | "member" | "viewer"
   teamId?: string | null
   planId?: string
   featureFlags?: string[]

--- a/lib/operational/routing.ts
+++ b/lib/operational/routing.ts
@@ -97,25 +97,35 @@ export async function classifyAndRoute(
     }
   }
   
-  // Update document with routing information. Merge into existing metadata
-  // rather than replacing it -- this runs after other pipeline steps
-  // (e.g. AI analysis) have already written their own metadata fields.
-  const { data: existing } = await db.from("documents").select("metadata").eq("id", documentId).maybeSingle()
-  const existingMetadata = (existing?.metadata as Record<string, unknown>) ?? {}
+  // The service-role client bypasses RLS, so both mutations must explicitly
+  // scope the document to its tenant. Metadata is merged atomically in
+  // Postgres to avoid clobbering analysis written by a concurrent pipeline.
+  const { error: classificationError } = await db
+    .from("documents")
+    .update({ classification: classification?.primary ?? null })
+    .eq("id", documentId)
+    .eq("organization_id", organizationId)
 
-  await db.from("documents").update({
-    classification: classification?.primary ?? null,
-    metadata: {
-      ...existingMetadata,
+  if (classificationError) throw classificationError
+
+  const { data: mergedMetadata, error: metadataError } = await db.rpc("merge_document_metadata", {
+    p_document_id: documentId,
+    p_organization_id: organizationId,
+    p_patch: {
       routed_to: target,
       intent: intent?.primary ?? null,
       routing_rules_applied: {
         classification: classification?.primary,
         intent: intent?.primary,
-        target_workspace: target
-      }
+        target_workspace: target,
+      },
     },
-  }).eq("id", documentId)
+  })
+
+  if (metadataError) throw metadataError
+  if (!mergedMetadata) {
+    throw new Error("Document not found in organization")
+  }
 
   return target
 }

--- a/lib/resources/assets.ts
+++ b/lib/resources/assets.ts
@@ -12,6 +12,22 @@ export interface AssetNode {
   created_at: string; updated_at: string
 }
 
+export interface CreateAssetInput {
+  name: string
+  category: string | null
+  subcategory: string | null
+  parent_id: string | null
+  serial_number: string | null
+  asset_tag: string | null
+  status: AssetNode["status"]
+  location: string | null
+  purchase_date: string | null
+  purchase_value: number | null
+  current_value: number | null
+  warranty_expiry: string | null
+  metadata: Record<string, unknown>
+}
+
 export async function listAssets(organizationId: string, category?: string): Promise<AssetNode[]> {
   const db = createServiceClient()
   let q = db.from("assets").select("*").eq("organization_id", organizationId).order("name")
@@ -20,9 +36,38 @@ export async function listAssets(organizationId: string, category?: string): Pro
   return (data ?? []) as AssetNode[]
 }
 
-export async function createAsset(organizationId: string, input: Partial<AssetNode>, userId: string): Promise<AssetNode | null> {
+export async function createAsset(organizationId: string, input: CreateAssetInput, userId: string): Promise<AssetNode | null> {
   const db = createServiceClient()
-  const { data, error } = await db.from("assets").insert({ organization_id: organizationId, ...input, created_by: userId }).select("*").single()
+
+  if (input.parent_id) {
+    const { data: parent } = await db
+      .from("assets")
+      .select("id")
+      .eq("id", input.parent_id)
+      .eq("organization_id", organizationId)
+      .maybeSingle()
+    if (!parent) return null
+  }
+
+  // Explicitly enumerate writable fields. organization_id, created_by, id,
+  // and timestamps are always server-owned and cannot be overridden by JSON.
+  const { data, error } = await db.from("assets").insert({
+    organization_id: organizationId,
+    created_by: userId,
+    name: input.name,
+    category: input.category,
+    subcategory: input.subcategory,
+    parent_id: input.parent_id,
+    serial_number: input.serial_number,
+    asset_tag: input.asset_tag,
+    status: input.status,
+    location: input.location,
+    purchase_date: input.purchase_date,
+    purchase_value: input.purchase_value,
+    current_value: input.current_value,
+    warranty_expiry: input.warranty_expiry,
+    metadata: input.metadata,
+  }).select("*").single()
   if (error) return null
   const asset = data as AssetNode
   await publish({ type: "resources.asset_created", organization_id: organizationId, data: { asset_id: asset.id, category: asset.category } })

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,65 @@
+const isProduction = process.env.NODE_ENV === 'production'
+
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "form-action 'self' https://checkout.stripe.com",
+  "script-src 'self' 'unsafe-inline' https://js.stripe.com" + (isProduction ? '' : " 'unsafe-eval'"),
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data:",
+  "connect-src 'self' https: wss:" + (isProduction ? '' : ' ws:'),
+  "frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://checkout.stripe.com",
+  "media-src 'self' blob: https:",
+  "worker-src 'self' blob:",
+  "manifest-src 'self'",
+  ...(isProduction ? ['upgrade-insecure-requests'] : []),
+].join('; ')
+
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: contentSecurityPolicy,
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(self), microphone=(self), geolocation=(), browsing-topics=(), payment=(self)',
+  },
+  ...(isProduction
+    ? [{
+        key: 'Strict-Transport-Security',
+        value: 'max-age=31536000; includeSubDomains',
+      }]
+    : []),
+]
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
   images: {
     unoptimized: true,
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ]
   },
 }
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "unpdf": "^1.6.2",
     "uuid": "^14.0.0",
     "vaul": "^1.1.2",
-    "xlsx": "^0.18.5",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^3.24.1"
   },
   "devDependencies": {
@@ -102,7 +102,7 @@
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.9",
     "jsdom": "^29.1.1",
-    "postcss": "^8.5",
+    "postcss": "^8.5.19",
     "tailwindcss": "^4.2.0",
     "tw-animate-css": "1.3.3",
     "typescript": "5.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  lodash: 4.18.1
+  postcss: 8.5.19
+
 importers:
 
   .:
@@ -148,7 +152,7 @@ importers:
         version: 6.0.189(zod@3.25.76)
       autoprefixer:
         specifier: ^10.4.20
-        version: 10.4.24(postcss@8.5.6)
+        version: 10.4.24(postcss@8.5.19)
       axios:
         specifier: ^1.17.0
         version: 1.17.0
@@ -237,8 +241,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       xlsx:
-        specifier: ^0.18.5
-        version: 0.18.5
+        specifier: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
+        version: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -274,8 +278,8 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1
       postcss:
-        specifier: ^8.5
-        version: 8.5.6
+        specifier: 8.5.19
+        version: 8.5.19
       tailwindcss:
         specifier: ^4.2.0
         version: 4.2.0
@@ -2626,10 +2630,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adler-32@1.3.1:
-    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
-    engines: {node: '>=0.8'}
-
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -2727,7 +2727,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.19
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -2803,10 +2803,6 @@ packages:
   caniuse-lite@1.0.30001769:
     resolution: {integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==}
 
-  cfb@1.2.2:
-    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
-    engines: {node: '>=0.8'}
-
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -2834,10 +2830,6 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
-  codepage@1.15.0:
-    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
-    engines: {node: '>=0.8'}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2858,11 +2850,6 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
-
-  crc-32@1.2.2:
-    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
-    engines: {node: '>=0.8'}
-    hasBin: true
 
   cron-parser@5.5.0:
     resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
@@ -3318,10 +3305,6 @@ packages:
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
-
-  frac@1.1.2:
-    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
-    engines: {node: '>=0.8'}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -3846,8 +3829,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -3921,11 +3904,6 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
@@ -4085,16 +4063,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -4387,10 +4357,6 @@ packages:
   speakeasy@2.0.0:
     resolution: {integrity: sha512-lW2A2s5LKi8rwu77ewisuUOtlCydF/hmQSOJjpTqTj1gZLkNgTaYnyvfxy2WBr4T/h+9c4g8HIITfj83OkFQFw==}
     engines: {node: '>= 0.10.0'}
-
-  ssf@0.11.2:
-    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
-    engines: {node: '>=0.8'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -4790,24 +4756,17 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wmf@1.0.2:
-    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
-    engines: {node: '>=0.8'}
-
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
-
-  word@0.3.0:
-    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
-    engines: {node: '>=0.8'}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
-  xlsx@0.18.5:
-    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
+    resolution: {integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==, tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
+    version: 0.20.3
     engines: {node: '>=0.8'}
     hasBin: true
 
@@ -6993,7 +6952,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.0
       '@tailwindcss/oxide': 4.2.0
-      postcss: 8.5.6
+      postcss: 8.5.19
       tailwindcss: 4.2.0
 
   '@tanstack/query-core@5.101.2': {}
@@ -7324,8 +7283,6 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  adler-32@1.3.1: {}
-
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -7450,13 +7407,13 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoprefixer@10.4.24(postcss@8.5.6):
+  autoprefixer@10.4.24(postcss@8.5.19):
     dependencies:
       browserslist: 4.28.1
       caniuse-lite: 1.0.30001769
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.19
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -7535,11 +7492,6 @@ snapshots:
 
   caniuse-lite@1.0.30001769: {}
 
-  cfb@1.2.2:
-    dependencies:
-      adler-32: 1.3.1
-      crc-32: 1.2.2
-
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -7573,8 +7525,6 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  codepage@1.15.0: {}
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -7590,8 +7540,6 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
-
-  crc-32@1.2.2: {}
 
   cron-parser@5.5.0:
     dependencies:
@@ -8203,8 +8151,6 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
-  frac@1.1.2: {}
-
   fraction.js@5.3.4: {}
 
   framer-motion@12.40.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -8679,7 +8625,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -8740,8 +8686,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.11: {}
-
   nanoid@3.3.15: {}
 
   napi-postinstall@0.3.4: {}
@@ -8759,7 +8703,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.9.19
       caniuse-lite: 1.0.30001769
-      postcss: 8.4.31
+      postcss: 8.5.19
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.4)
@@ -8894,21 +8838,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.15:
+  postcss@8.5.19:
     dependencies:
       nanoid: 3.3.15
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.6:
-    dependencies:
-      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -9040,7 +8972,7 @@ snapshots:
     dependencies:
       clsx: 2.1.1
       eventemitter3: 4.0.7
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-is: 18.3.1
@@ -9260,10 +9192,6 @@ snapshots:
   speakeasy@2.0.0:
     dependencies:
       base32.js: 0.0.1
-
-  ssf@0.11.2:
-    dependencies:
-      frac: 1.1.2
 
   stable-hash@0.0.5: {}
 
@@ -9588,7 +9516,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.19
       rolldown: 1.1.2
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -9694,11 +9622,7 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wmf@1.0.2: {}
-
   word-wrap@1.2.5: {}
-
-  word@0.3.0: {}
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -9706,15 +9630,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  xlsx@0.18.5:
-    dependencies:
-      adler-32: 1.3.1
-      cfb: 1.2.2
-      codepage: 1.15.0
-      crc-32: 1.2.2
-      ssf: 0.11.2
-      wmf: 1.0.2
-      word: 0.3.0
+  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,6 @@ onlyBuiltDependencies:
   - esbuild
   - sharp
   - unrs-resolver
+overrides:
+  lodash: 4.18.1
+  postcss: 8.5.19

--- a/supabase/migrations/20260718100000_merge_document_metadata.sql
+++ b/supabase/migrations/20260718100000_merge_document_metadata.sql
@@ -1,0 +1,28 @@
+-- Atomically merge document metadata while preserving the tenant boundary.
+-- Only trusted server-side service-role callers may execute this function.
+CREATE OR REPLACE FUNCTION public.merge_document_metadata(
+  p_document_id UUID,
+  p_organization_id UUID,
+  p_patch JSONB
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  result JSONB;
+BEGIN
+  UPDATE public.documents
+  SET metadata = COALESCE(metadata, '{}'::jsonb) || p_patch
+  WHERE id = p_document_id
+    AND organization_id = p_organization_id
+  RETURNING metadata INTO result;
+
+  RETURN result;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.merge_document_metadata(UUID, UUID, JSONB) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.merge_document_metadata(UUID, UUID, JSONB) FROM anon;
+REVOKE ALL ON FUNCTION public.merge_document_metadata(UUID, UUID, JSONB) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.merge_document_metadata(UUID, UUID, JSONB) TO service_role;

--- a/supabase/migrations/20260719010000_webhook_event_leases.sql
+++ b/supabase/migrations/20260719010000_webhook_event_leases.sql
@@ -1,0 +1,23 @@
+ALTER TABLE webhook_events
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'completed',
+  ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS last_error TEXT,
+  ADD COLUMN IF NOT EXISTS attempts INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE webhook_events
+  DROP CONSTRAINT IF EXISTS webhook_events_status_check;
+
+ALTER TABLE webhook_events
+  ADD CONSTRAINT webhook_events_status_check
+  CHECK (status IN ('processing', 'completed', 'failed'));
+
+UPDATE webhook_events
+SET status = 'completed',
+    claimed_at = COALESCE(claimed_at, created_at),
+    completed_at = COALESCE(completed_at, created_at)
+WHERE status = 'completed';
+
+CREATE INDEX IF NOT EXISTS idx_webhook_events_processing_lease
+  ON webhook_events(status, claimed_at)
+  WHERE status = 'processing';

--- a/supabase/migrations/20260818000000_passkey_authentication_challenges.sql
+++ b/supabase/migrations/20260818000000_passkey_authentication_challenges.sql
@@ -1,0 +1,16 @@
+-- One-time, anonymous authentication challenges for discoverable passkeys.
+-- The browser receives only an opaque flow ID in an HttpOnly cookie; the
+-- challenge itself remains server-side and is deleted atomically on use.
+CREATE TABLE IF NOT EXISTS public.passkey_authentication_challenges (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  challenge TEXT NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_passkey_authentication_challenges_expires_at
+  ON public.passkey_authentication_challenges(expires_at);
+
+ALTER TABLE public.passkey_authentication_challenges ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.passkey_authentication_challenges FROM anon, authenticated;
+GRANT ALL ON TABLE public.passkey_authentication_challenges TO service_role;

--- a/supabase/migrations/20260818010000_passkey_registration_security.sql
+++ b/supabase/migrations/20260818010000_passkey_registration_security.sql
@@ -1,0 +1,65 @@
+-- Canonical credential store used by /api/auth/passkeys/register and
+-- /api/auth/passkeys/authenticate. Older environments created this table
+-- outside the tracked migrations, so keep this migration idempotent.
+CREATE TABLE IF NOT EXISTS public.passkeys (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  credential_id TEXT NOT NULL,
+  public_key TEXT NOT NULL,
+  counter BIGINT NOT NULL DEFAULT 0,
+  device_name TEXT NOT NULL DEFAULT 'Unknown Device',
+  transports TEXT[] NOT NULL DEFAULT '{}',
+  last_used_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.passkeys ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE;
+ALTER TABLE public.passkeys ADD COLUMN IF NOT EXISTS credential_id TEXT;
+ALTER TABLE public.passkeys ADD COLUMN IF NOT EXISTS public_key TEXT;
+ALTER TABLE public.passkeys ADD COLUMN IF NOT EXISTS counter BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE public.passkeys ADD COLUMN IF NOT EXISTS device_name TEXT NOT NULL DEFAULT 'Unknown Device';
+ALTER TABLE public.passkeys ADD COLUMN IF NOT EXISTS transports TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE public.passkeys ADD COLUMN IF NOT EXISTS last_used_at TIMESTAMPTZ;
+ALTER TABLE public.passkeys ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE public.passkeys ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE public.passkeys ALTER COLUMN credential_id SET NOT NULL;
+ALTER TABLE public.passkeys ALTER COLUMN public_key SET NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_passkeys_credential_id ON public.passkeys(credential_id);
+CREATE INDEX IF NOT EXISTS idx_passkeys_user_id ON public.passkeys(user_id);
+
+ALTER TABLE public.passkeys ENABLE ROW LEVEL SECURITY;
+-- Replace any untracked legacy policies so no permissive insert/update policy
+-- can bypass the authenticated, server-owned registration ceremony.
+DO $$
+DECLARE policy_name TEXT;
+BEGIN
+  FOR policy_name IN
+    SELECT policyname FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'passkeys'
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.passkeys', policy_name);
+  END LOOP;
+END $$;
+REVOKE ALL ON TABLE public.passkeys FROM anon, authenticated;
+GRANT ALL ON TABLE public.passkeys TO service_role;
+GRANT SELECT, DELETE ON TABLE public.passkeys TO authenticated;
+CREATE POLICY "Users can read their own passkeys" ON public.passkeys
+  FOR SELECT TO authenticated USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete their own passkeys" ON public.passkeys
+  FOR DELETE TO authenticated USING (auth.uid() = user_id);
+
+-- Registration flows are user-bound and server-only. Delete-and-return in the
+-- route consumes a challenge exactly once before credential verification.
+CREATE TABLE IF NOT EXISTS public.passkey_registration_challenges (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  challenge TEXT NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_passkey_registration_challenges_user
+  ON public.passkey_registration_challenges(user_id, expires_at);
+ALTER TABLE public.passkey_registration_challenges ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.passkey_registration_challenges FROM anon, authenticated;
+GRANT ALL ON TABLE public.passkey_registration_challenges TO service_role;

--- a/supabase/migrations/20260818020000_esignature_tenant_integrity.sql
+++ b/supabase/migrations/20260818020000_esignature_tenant_integrity.sql
@@ -1,0 +1,22 @@
+-- Enforce the document tenant boundary below the service-role application
+-- layer. A request/record may reference only a document in the same org.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_org_id_unique
+  ON public.documents(organization_id, id);
+
+ALTER TABLE public.esignature_requests
+  DROP CONSTRAINT IF EXISTS esignature_requests_document_tenant_fkey;
+ALTER TABLE public.esignature_requests
+  ADD CONSTRAINT esignature_requests_document_tenant_fkey
+  FOREIGN KEY (organization_id, document_id)
+  REFERENCES public.documents(organization_id, id)
+  ON DELETE CASCADE
+  NOT VALID;
+
+ALTER TABLE public.esignature_records
+  DROP CONSTRAINT IF EXISTS esignature_records_document_tenant_fkey;
+ALTER TABLE public.esignature_records
+  ADD CONSTRAINT esignature_records_document_tenant_fkey
+  FOREIGN KEY (organization_id, document_id)
+  REFERENCES public.documents(organization_id, id)
+  ON DELETE CASCADE
+  NOT VALID;

--- a/supabase/migrations/20260818030000_asset_tenant_integrity.sql
+++ b/supabase/migrations/20260818030000_asset_tenant_integrity.sql
@@ -1,0 +1,14 @@
+-- Asset hierarchies may only connect rows inside the same tenant. NOT VALID
+-- enforces this for new writes while allowing legacy rows to be audited before
+-- a later VALIDATE CONSTRAINT rollout.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_assets_org_id_unique
+  ON public.assets(organization_id, id);
+
+ALTER TABLE public.assets DROP CONSTRAINT IF EXISTS assets_parent_id_fkey;
+ALTER TABLE public.assets DROP CONSTRAINT IF EXISTS assets_parent_tenant_fkey;
+ALTER TABLE public.assets
+  ADD CONSTRAINT assets_parent_tenant_fkey
+  FOREIGN KEY (organization_id, parent_id)
+  REFERENCES public.assets(organization_id, id)
+  ON DELETE SET NULL (parent_id)
+  NOT VALID;

--- a/supabase/migrations/20260818040000_harden_materialized_view_functions.sql
+++ b/supabase/migrations/20260818040000_harden_materialized_view_functions.sql
@@ -1,0 +1,18 @@
+-- These SECURITY DEFINER functions operate on platform-wide materialized
+-- views. PostgreSQL grants EXECUTE to PUBLIC on new functions unless it is
+-- explicitly revoked, which allowed anonymous RPC callers to trigger costly
+-- global refreshes and observe cross-tenant aggregate row counts.
+
+ALTER FUNCTION public.refresh_known_materialized_view(TEXT)
+  SET search_path = pg_catalog, public;
+REVOKE ALL ON FUNCTION public.refresh_known_materialized_view(TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.refresh_known_materialized_view(TEXT) FROM anon;
+REVOKE ALL ON FUNCTION public.refresh_known_materialized_view(TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.refresh_known_materialized_view(TEXT) TO service_role;
+
+ALTER FUNCTION public.count_materialized_view_rows(TEXT)
+  SET search_path = pg_catalog, public;
+REVOKE ALL ON FUNCTION public.count_materialized_view_rows(TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.count_materialized_view_rows(TEXT) FROM anon;
+REVOKE ALL ON FUNCTION public.count_materialized_view_rows(TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.count_materialized_view_rows(TEXT) TO service_role;


### PR DESCRIPTION
## Summary
- Bind trial, onboarding, passwordless, WebAuthn, and passkey flows to verified server identities.
- Store and atomically consume passkey challenges; create real Supabase sessions after successful proof.
- Enforce tenant scope in auto-routing and notifications.
- Authenticate legacy ingestion and verify Meta webhook signatures.
- Bound document uploads and spreadsheet parsing.
- Disable simulated identity/KYC approvals in production.
- Add production security headers and remediate all production dependency advisories.
- Repair billing tests and reject invalid/future refund dates.

## Required before deployment
- Apply all included Supabase migrations, especially passkey challenge/schema migrations and the metadata merge RPC.
- Configure `WHATSAPP_APP_SECRET`, `CRON_SECRET`, Supabase service credentials, and canonical `NEXT_PUBLIC_APP_URL`.
- Production identity endpoints intentionally fail closed until real KYC/liveness providers are configured.

## Validation
- `pnpm audit --prod`: no known vulnerabilities
- `pnpm test`: 7 files, 66 tests passed
- `pnpm exec tsc --noEmit`: passed
- `pnpm run build`: passed during remediation
- Targeted ESLint and diff checks: passed

This remains a draft because no GitHub status checks are configured and database migrations must be applied before deployment. GitLab/Coolify deployment should run only after review and merge to `main`.
